### PR TITLE
docs: rename Phase 2 ship from v0.2.0 to v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [v0.1.0] — 2026-04-25
+
 ### Added
 
 - Phase 2: two new artifact kinds — `KindMarketplace` for
@@ -73,5 +75,6 @@ this project adheres to [Semantic Versioning](https://semver.org/).
   the plugin root (no `.claude/` parent). Prior versions silently
   ignored every plugin artifact outside the `.claude/` convention.
 
-[Unreleased]: https://github.com/donaldgifford/claudelint/compare/v0.0.1...HEAD
+[Unreleased]: https://github.com/donaldgifford/claudelint/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/donaldgifford/claudelint/compare/v0.0.1...v0.1.0
 [v0.0.1]: https://github.com/donaldgifford/claudelint/compare/v0.0.0...v0.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project status
 
-Phase 1 MVP shipped (v0.0.1). Phase 2 feature-complete on branch `docs/impl-0002-phase-2`; PR [#9](https://github.com/donaldgifford/claudelint/pull/9) is green and labeled `minor` so `jefflinse/pr-semver-bump` cuts `v0.2.0` on merge. Ruleset is `v1.1.0`, fingerprint `4cee5ee7`.
+Phase 1 MVP shipped as v0.0.1. Phase 2 shipped as **v0.1.0** (PR [#9](https://github.com/donaldgifford/claudelint/pull/9) merged 2026-04-25 → release published the same day). Ruleset is `v1.1.0`, fingerprint `4cee5ee7`. (IMPL-0002 calls it "v0.2.0" throughout — that was the planning name; semver math from `v0.0.1 + minor` actually produces `v0.1.0`.)
 
-Phase 2 delivered: two new artifact kinds (`KindMarketplace`, `KindMCPServer`), eight marketplace rules, six MCP rules, `Rule.HelpURI()`, `claudelint rules --json`, `--format=sarif` with vendored SARIF 2.1.0 schema validation, a multi-arch `ghcr.io/donaldgifford/claudelint` image via goreleaser, and companion-action scaffolding at `companion/claudelint-action/` ready to push to `donaldgifford/claudelint-action` once v0.2.0 is tagged. INV-0005 captures the `donaldgifford/claude-skills` dogfood pass; two false positives (nested marketplace shape, missing `AskUserQuestion`) were fixed in-flight.
+Phase 2 delivered: two new artifact kinds (`KindMarketplace`, `KindMCPServer`), eight marketplace rules, six MCP rules, `Rule.HelpURI()`, `claudelint rules --json`, `--format=sarif` with vendored SARIF 2.1.0 schema validation, a multi-arch `ghcr.io/donaldgifford/claudelint` image via goreleaser (tags: `0.1.0`, `v0`, `v0.1`, `latest`), and companion-action scaffolding at `companion/claudelint-action/` ready to push to `donaldgifford/claudelint-action`. INV-0005 captures the `donaldgifford/claude-skills` dogfood pass; two false positives (nested marketplace shape, missing `AskUserQuestion`) were fixed in-flight.
 
 `run` supports `--format=text|json|github|sarif`, `--sarif-file=<path>`, `--quiet`, `--verbose`, `--max-warnings=N`, `--no-color`, `--profile=<dir>` (pprof), and exit codes (0/1/2). `make self-check`, `make coverage-gate`, `make bench`, and `make profile` are all wired. Phase 1 dogfooding captured in INV-0003.
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Or upload SARIF to Code Scanning:
 docker run --rm -v "$PWD:/src" -w /src ghcr.io/donaldgifford/claudelint:latest run .
 ```
 
-The image pins a tag per release (`:v0.2.0`, `:v0`, `:latest`). Use the
-pinned tag in scheduled pipelines to avoid surprises when claudelint
-ships a new rule.
+The image pins a tag per release (`:0.1.0`, `:v0`, `:v0.1`, `:latest`).
+Use a pinned tag in scheduled pipelines to avoid surprises when
+claudelint ships a new rule.
 
 ## Exit codes
 

--- a/companion/claudelint-action/README.md
+++ b/companion/claudelint-action/README.md
@@ -52,7 +52,7 @@ need a second step.
 ```yaml
       - uses: donaldgifford/claudelint-action@v1
         with:
-          version: v0.2.0
+          version: v0.1.0
 ```
 
 `latest` resolves to the most recent release tag at runtime via the
@@ -62,7 +62,7 @@ GitHub API. Pinning is recommended for deterministic CI.
 
 | Name             | Default      | Description |
 |------------------|--------------|-------------|
-| `version`        | `latest`     | claudelint release tag to download (e.g. `v0.2.0`). |
+| `version`        | `latest`     | claudelint release tag to download (e.g. `v0.1.0`). |
 | `path`           | `.`          | Space-separated paths to lint. |
 | `format`         | `github`     | `text`, `json`, `github`, or `sarif`. |
 | `config`         | *(discovery)*| Explicit path to `.claudelint.hcl`. |

--- a/companion/claudelint-action/action.yml
+++ b/companion/claudelint-action/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   version:
-    description: 'claudelint version to install (e.g. v0.2.0, or "latest")'
+    description: 'claudelint version to install (e.g. v0.1.0, or "latest")'
     required: false
     default: "latest"
   path:

--- a/docs/investigation/0005-phase-2-dogfood-findings-marketplaces-mcp-and-spec-divergence.md
+++ b/docs/investigation/0005-phase-2-dogfood-findings-marketplaces-mcp-and-spec-divergence.md
@@ -72,7 +72,7 @@ that generates the problems.
 
 | Component      | Version / Value                                      |
 |----------------|------------------------------------------------------|
-| `claudelint`   | pre-v0.2.0 (branch `docs/impl-0002-phase-2`, ruleset v1.1.0, fingerprint `4cee5ee7`) |
+| `claudelint`   | pre-v0.1.0 (branch `docs/impl-0002-phase-2`, ruleset v1.1.0, fingerprint `4cee5ee7`) |
 | Go             | 1.26.1                                               |
 | Marketplace    | `donaldgifford/claude-skills` at `~/code/claude-skills` (HEAD, 2026-04-23) |
 
@@ -198,10 +198,11 @@ SKILL). Ship-ready.
 
 ## Recommendation
 
-- **Ship v0.2.0** with the marketplace-parser fix and the `KnownTools`
-  addition included. The ruleset produces actionable diagnostics on
-  conforming marketplaces with no known false positives on the primary
-  dogfood target.
+- **Ship v0.1.0** (note: IMPL-0002 calls the Phase 2 release "v0.2.0";
+  semver math from `v0.0.1 + minor` actually produces v0.1.0, which is
+  what the release workflow tagged). The ruleset produces actionable
+  diagnostics on conforming marketplaces with no known false positives
+  on the primary dogfood target.
 - **Monitor:** future additions to the Claude Code tool set need a
   corresponding one-line bump to `artifact.KnownTools`.
 - **Leave open:** if another marketplace surfaces yet another shape


### PR DESCRIPTION
## Summary

Follow-up to #9. The Phase 2 release workflow correctly bumped `v0.0.1 + minor → v0.1.0`, but the plan docs (CHANGELOG, CLAUDE.md, README, INV-0005, companion README + action.yml) had been calling it `v0.2.0` all along — an off-by-one against actual semver math. This updates the ship-state docs to match what actually shipped.

- **CHANGELOG**: promotes the `[Unreleased]` block to `[v0.1.0]` (2026-04-25); adds the missing compare link.
- **CLAUDE.md**: project status now reflects PR #9 merged + v0.1.0 shipped, with a note that IMPL-0002's "v0.2.0" was the planning name.
- **README**: Docker image tag examples switched to `:0.1.0` / `:v0.1` (goreleaser strips the leading `v` on the bare-version tag).
- **INV-0005**: environment row + ship recommendation now say v0.1.0, with a pointer at the IMPL-0002 naming history.
- **companion/claudelint-action/{README.md,action.yml}**: pin examples reference `v0.1.0`.

IMPL-0002 and DESIGN-0002 are left as-is — they're historical planning docs, and the "v0.2.0" naming there documents the original intent.

## Test plan

- [x] \`make lint\` clean.
- [x] \`go test ./...\` passes (no version-coupled test asserts).
- [x] Reviewed CHANGELOG diff — \`[v0.1.0]\` block reads correctly, compare link points at \`v0.0.1...v0.1.0\`, and \`[Unreleased]\` rebases onto \`v0.1.0...HEAD\`.
- [x] Confirmed \`dont-release\` label is on the PR so \`pr-semver-bump\` skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)