### PR TITLE
fix(hooks): parse nested shape uniformly; drop unsupported flat shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `hooks/timeout-present` no longer false-fires on plugin
+  `hooks/hooks.json` files that declare `timeout` per inner entry. The
+  hook parser previously dispatched non-`settings.json` files to a flat
+  `{event, matcher, command, timeout}` shape that does not appear in
+  the Claude Code docs, causing `Timeout` to read as 0 for every entry
+  in a real plugin hook file. The parser now uses the canonical nested
+  `{"hooks": {"<EventName>": [{"matcher": "...", "hooks": [...]}]}}`
+  shape uniformly. (#14)
+
+### Changed
+
+- **Breaking:** the hook parser no longer accepts the flat
+  `{event, matcher, command, timeout}` top-level shape. A dedicated
+  hook file (`.claude/hooks/*.json`, plugin `hooks/hooks.json`) that
+  is missing the `hooks` key now fails parsing with `*ParseError`
+  rather than silently producing an entry with `Timeout == 0`.
+  Settings files (`.claude/settings{,.local}.json`) may still omit
+  the `hooks` key. The flat shape was a parser-author assumption that
+  did not match Claude Code's documented hook schema; see
+  `docs/design/0001-*.md` "Hook shape" for the rationale and the
+  best-effort handling of `.claude/hooks/*.json`.
+
 ## [v0.1.0] — 2026-04-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The architecture and phased rollout are specified in `docs/` — **read the docs
 - `docs/impl/0001-*.md` — Phase 1 task breakdown
 - `docs/impl/0002-*.md` — Phase 2 task breakdown with success criteria per sub-phase
 
-When continuing Phase 2, follow IMPL-0002 in order. Do not improvise architecture that contradicts DESIGN-0002 without updating the doc first.
+Phase 2 is shipped. The next outstanding work is bootstrapping the `donaldgifford/claudelint-action` repo from `companion/claudelint-action/` (instructions in `companion/README.md`) and tagging it `v1.0.0` once its own test workflow is green. After that, Phase 3 (`convert` subcommand, gated on INV-0001) is the next planned phase. When extending an existing phase or planning a new one, follow the corresponding IMPL doc in order; do not improvise architecture that contradicts the matching DESIGN doc without updating it first.
 
 ## Architecture (target)
 
@@ -89,6 +89,7 @@ Use `Skill` with the `docz:*` skills for doc lifecycle work rather than reinvent
 
 - Branch prefixes drive auto-labeling (`.github/labeler.yml`): `feat/`, `fix/`, `chore/`, `docs/`, `bug/`. Use the `git-workflow:branch` skill.
 - **Releases are label-driven, not manual.** `.github/workflows/release.yml` runs `jefflinse/pr-semver-bump` on every push to `main`; the merged PR's label (`major` / `minor` / `patch` / `dont-release`) determines the version bump and tag. Do **not** run `git tag` or `make release TAG=...` by hand — it would race the workflow. (`RELEASE.md` predates this and is stale for Phase 1; keep that in mind when reading it.)
+- **Squash-merge subject must keep the `(#N)` suffix.** `pr-semver-bump` looks at the merge-commit message for the PR number; if you override `--subject` with `gh pr merge` and drop the suffix, the SHA-based fallback often fails (search-API indexing lag) and the workflow errors out. Either accept GitHub's default subject or include `(#N)` manually.
 - Release assets are defined in `.goreleaser.yml`; `.codecov.yml` gates coverage reporting.
-- **No Docker distribution in Phase 1.** The docker-build CI job and the `docker:` release job were removed (they referenced a nonexistent `docker-bake.hcl`). If Docker comes back in a later phase, a real `docker-bake.hcl` + `Dockerfile` need to land first.
+- **Docker images** ship from the same goreleaser run as the binaries (Phase 2 onward). Image is `ghcr.io/donaldgifford/claudelint`; tag layout per release is `:<version>` **without leading `v`** (goreleaser strips it on the bare-version tag), plus `:v<major>`, `:v<major>.<minor>`, and `:latest`. Multi-arch manifest covers `linux/amd64` + `linux/arm64`.
 - **GPG release signing:** the `GPG_PRIVATE_KEY` repo secret must be the output of `gpg --armor --export-secret-keys <keyid>` (begins with `-----BEGIN PGP PRIVATE KEY BLOCK-----`). The public-export variant imports cleanly but fails at sign-time with `gpg: skipped "***": No secret key`. `GPG_FINGERPRINT` is also required.

--- a/README.md
+++ b/README.md
@@ -273,24 +273,39 @@ entry is a valid Claude tool name from the shipping set.
 
 #### `hooks/event-name-known`
 
-Hook config events must match one of the known Claude hook events
-(`PreToolUse`, `PostToolUse`, `Stop`, etc.).
+Each top-level key under `"hooks"` is the event name. It must match
+one of the known Claude Code hook events (`PreToolUse`, `PostToolUse`,
+`Stop`, etc.).
 
-**Bad**: `on: PretoolUse` (wrong case / typo)
-**Fix**: `on: PreToolUse`.
+**Bad**: `"PretoolUse": [...]` (wrong case / typo)
+**Fix**: `"PreToolUse": [...]`.
 
 #### `hooks/timeout-present`
 
-Every hook entry should declare a timeout so a runaway hook cannot
-hang the session.
+Every hook entry should declare a `timeout` (seconds) so a runaway
+hook cannot hang the session.
 
 **Bad**:
 
-    hooks:
-      - on: PreToolUse
-        command: lint-check
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "hooks": [{ "type": "command", "command": "lint-check" }] }
+    ]
+  }
+}
+```
 
-**Fix**: add `timeout: 5s` to the entry.
+**Fix**: add `"timeout": 5` to the inner hook entry.
+
+> **Hook shape.** claudelint parses every hook file — settings,
+> plugin `hooks/hooks.json`, `.claude/hooks/*.json` — using the same
+> nested layout above. A dedicated hook file missing the top-level
+> `"hooks"` key fails parsing with a `schema/parse` error rather
+> than silently producing zero-timeout entries. See
+> [DESIGN-0001 §Hook shape](docs/design/0001-claudelint-linter-architecture-and-rule-engine.md)
+> for the rationale and the best-effort handling of `.claude/hooks/*.json`.
 
 #### `hooks/no-unsafe-shell`
 

--- a/docs/design/0001-claudelint-linter-architecture-and-rule-engine.md
+++ b/docs/design/0001-claudelint-linter-architecture-and-rule-engine.md
@@ -293,11 +293,57 @@ automatically.
 | `skill` | Frontmatter (`name`, `description`, optional `allowed-tools`, `model`) + Markdown body. Companion files indexed. |
 | `command` | Frontmatter (`description`, `argument-hint`, `allowed-tools`) + body. |
 | `agent` | Frontmatter (`name`, `description`, `tools`) + system prompt body. |
-| `hook` | JSON — either dedicated file or the `hooks` stanza inside `settings.json`. |
+| `hook` | JSON. Single canonical nested shape `{"hooks": {"<EventName>": [{"matcher": "...", "hooks": [{"command": "...", "timeout": <s>}]}]}}` — see "Hook shape" note below. |
 | `plugin` | JSON or YAML manifest; fields per the Claude plugin spec (`name`, `version`, `commands`, `skills`, `agents`, …). |
 
 All parsers preserve byte offsets so diagnostics can report exact
 line/column ranges, including inside Markdown bodies.
+
+#### Hook shape
+
+The hook parser accepts one canonical shape for every file it sees,
+regardless of location:
+
+```json
+{
+  "hooks": {
+    "<EventName>": [
+      {
+        "matcher": "<pattern>",
+        "hooks": [
+          { "type": "command", "command": "<cmd>", "timeout": <s> }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This is the shape Claude Code documents at
+<https://docs.claude.com/en/docs/claude-code/hooks> for both
+`.claude/settings{,.local}.json` and plugin `hooks/hooks.json`.
+
+Discovery also classifies `.claude/hooks/*.json` as `KindHook`. Claude
+Code does not document this layout canonically; claudelint accepts it
+on a **best-effort** basis using the same nested shape. The parser
+flips `Hook.Embedded` only for settings files (the hooks key shares a
+file with other Claude Code config) — dedicated hook files have
+`Embedded = false` regardless of their parent directory.
+
+Failure is loud:
+
+- a syntactically invalid JSON file → `*ParseError`
+- a `hooks` key present but not an object → `*ParseError`
+- a dedicated hook file missing the `hooks` key entirely → `*ParseError`
+  (settings files may omit it — they may simply carry no hooks)
+
+Earlier versions of the parser also accepted a flat
+`{event, matcher, command, timeout}` shape for dedicated hook files.
+That shape never appeared in Claude Code's docs and silently produced
+`Timeout == 0` when the real nested shape was used inside one of
+those files (issue #14). It has been removed; an unknown shape now
+fails loudly so the user gets a parse error instead of misleading
+content diagnostics.
 
 ### Built-in rules (MVP shortlist)
 

--- a/internal/artifact/parse_json.go
+++ b/internal/artifact/parse_json.go
@@ -11,18 +11,41 @@ import (
 	"github.com/donaldgifford/claudelint/internal/diag"
 )
 
-// ParseHook parses a hook declaration. It recognizes two source shapes:
+// ParseHook parses a hook declaration. claudelint accepts a single
+// canonical shape regardless of which file it appears in:
 //
-//  1. A dedicated file under .claude/hooks/*.json whose top-level
-//     object is a single hook (keys: event, matcher, command,
-//     timeout).
-//  2. A .claude/settings{,.local}.json whose "hooks" stanza maps
-//     event names to arrays of matcher groups, each containing an
-//     array of hook commands. All entries are flattened into
-//     Hook.Entries.
+//	{
+//	  "hooks": {
+//	    "<EventName>": [
+//	      { "matcher": "<pattern>", "hooks": [
+//	          { "type": "command", "command": "<cmd>", "timeout": <s> }
+//	      ] }
+//	    ]
+//	  }
+//	}
 //
-// Parse errors (syntactically invalid JSON, hooks that are not an
-// object) yield a *ParseError pointing at the offending bytes.
+// This is the shape Claude Code documents for both
+// .claude/settings{,.local}.json and plugin hooks/hooks.json (see
+// https://docs.claude.com/en/docs/claude-code/hooks). Discovery also
+// classifies .claude/hooks/*.json as KindHook even though that path
+// is not canonically documented; we accept it on a best-effort basis
+// using the same nested shape.
+//
+// Hook.Embedded is true when the source file is a settings.json (the
+// hooks share a file with other Claude Code config) and false for
+// dedicated hook files.
+//
+// Failure modes:
+//   - syntactically invalid JSON → *ParseError
+//   - "hooks" key present but not an object → *ParseError
+//   - dedicated hook file missing the "hooks" key entirely → *ParseError
+//     (settings files are allowed to omit it; the file may carry no hooks)
+//
+// Earlier versions of the parser also accepted a flat
+// {event, matcher, command, timeout} shape for dedicated hook files.
+// That shape never appeared in Claude Code's documentation and produced
+// silent zero-Timeout values when the real nested shape was used (see
+// issue #14). It has been removed; an unknown shape now fails loudly.
 func ParseHook(path string, src []byte) (*Hook, *ParseError) {
 	base := NewBase(path, src)
 
@@ -36,16 +59,25 @@ func ParseHook(path string, src []byte) (*Hook, *ParseError) {
 	}
 
 	h := &Hook{Base: base}
+	settings := isSettingsFile(path)
+	h.Embedded = settings
 
-	if isSettingsFile(path) {
-		h.Embedded = true
-		if err := collectSettingsHooks(src, &base, h); err != nil {
-			return nil, &ParseError{Path: path, Message: err.Error(), Cause: err}
+	missingHooksKey, err := collectHooks(src, &base, h)
+	if err != nil {
+		return nil, &ParseError{
+			Path:    path,
+			Range:   base.ResolveRange(0, len(src)),
+			Message: err.Error(),
+			Cause:   err,
 		}
-		return h, nil
 	}
-
-	h.Entries = append(h.Entries, parseSingleHook(src, &base))
+	if missingHooksKey && !settings {
+		return nil, &ParseError{
+			Path:    path,
+			Range:   base.ResolveRange(0, len(src)),
+			Message: `hook file is missing the top-level "hooks" key; expected {"hooks": {"<EventName>": [{"hooks": [{"command": "...", "timeout": <s>}]}]}}`,
+		}
+	}
 	return h, nil
 }
 
@@ -82,39 +114,35 @@ func ParsePlugin(path string, src []byte) (*Plugin, *ParseError) {
 	return p, nil
 }
 
-// parseSingleHook builds a HookEntry from a flat hook object.
-func parseSingleHook(src []byte, base *Base) HookEntry {
-	e := HookEntry{}
-	e.Event, e.EventRange = stringField(src, base, "event")
-	e.Matcher, e.MatcherRange = stringField(src, base, "matcher")
-	e.Command, e.CommandRange = stringField(src, base, "command")
-	e.Timeout, e.TimeoutRange = intField(src, base, "timeout")
-	return e
-}
-
-// collectSettingsHooks walks the "hooks" stanza of a settings file and
-// flattens every (event, matcher, command) triple into Hook.Entries.
-// Settings files that have no hooks key simply produce an empty Entries
-// slice — absence is not an error.
-func collectSettingsHooks(src []byte, base *Base, h *Hook) error {
-	hooksRaw, dt, _, err := jsonparser.Get(src, "hooks")
-	if err != nil {
-		if errors.Is(err, jsonparser.KeyPathNotFoundError) {
-			return nil
+// collectHooks walks the "hooks" stanza and flattens every
+// (event, matcher, command) triple into Hook.Entries. The same nested
+// shape applies to .claude/settings{,.local}.json, plugin
+// hooks/hooks.json, and any .claude/hooks/*.json discovered by the
+// classifier.
+//
+// The first return value reports whether the top-level "hooks" key was
+// absent. Callers decide whether absence is an error (dedicated hook
+// files) or acceptable (settings files that carry no hooks).
+func collectHooks(src []byte, base *Base, h *Hook) (missing bool, err error) {
+	hooksRaw, dt, _, gerr := jsonparser.Get(src, "hooks")
+	if gerr != nil {
+		if errors.Is(gerr, jsonparser.KeyPathNotFoundError) {
+			return true, nil
 		}
-		return fmt.Errorf("settings.hooks: %w", err)
+		return false, fmt.Errorf("hooks: %w", gerr)
 	}
 	if dt != jsonparser.Object {
-		return fmt.Errorf("settings.hooks must be an object, got %s", dt.String())
+		return false, fmt.Errorf("hooks must be an object, got %s", dt.String())
 	}
 
-	return jsonparser.ObjectEach(hooksRaw, func(eventKey, groups []byte, _ jsonparser.ValueType, _ int) error {
+	walkErr := jsonparser.ObjectEach(hooksRaw, func(eventKey, groups []byte, _ jsonparser.ValueType, _ int) error {
 		event := string(eventKey)
-		_, err := jsonparser.ArrayEach(groups, func(group []byte, _ jsonparser.ValueType, _ int, _ error) {
+		_, aerr := jsonparser.ArrayEach(groups, func(group []byte, _ jsonparser.ValueType, _ int, _ error) {
 			collectMatcherGroup(group, base, event, h)
 		})
-		return err
+		return aerr
 	})
+	return false, walkErr
 }
 
 // collectMatcherGroup pulls every { matcher, hooks: [...] } item out

--- a/internal/artifact/parse_json_test.go
+++ b/internal/artifact/parse_json_test.go
@@ -6,7 +6,18 @@ import (
 )
 
 func TestParseHookDedicatedFile(t *testing.T) {
-	src := []byte(`{"event":"PreToolUse","matcher":"Bash","command":"echo ok","timeout":30}`)
+	src := []byte(`{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "echo ok", "timeout": 30 }
+        ]
+      }
+    ]
+  }
+}`)
 	h, perr := ParseHook(".claude/hooks/guard.json", src)
 	if perr != nil {
 		t.Fatalf("ParseHook = %v, want nil", perr)
@@ -30,8 +41,68 @@ func TestParseHookDedicatedFile(t *testing.T) {
 	if e.Timeout != 30 {
 		t.Errorf("Timeout = %d, want 30", e.Timeout)
 	}
-	if e.EventRange.IsZero() {
-		t.Errorf("EventRange should be populated")
+	if e.CommandRange.IsZero() {
+		t.Errorf("CommandRange should be populated")
+	}
+}
+
+// TestParseHookPluginNestedShape covers the regression behind
+// issue #14: a plugin hooks/hooks.json with timeout declared per
+// inner entry was previously read by the flat-shape parser, which
+// looked for `timeout` at the top level and produced Timeout == 0.
+func TestParseHookPluginNestedShape(t *testing.T) {
+	src := []byte(`{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash do-thing.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}`)
+	h, perr := ParseHook("plugins/example/hooks/hooks.json", src)
+	if perr != nil {
+		t.Fatalf("ParseHook = %v, want nil", perr)
+	}
+	if h.Embedded {
+		t.Errorf("plugin hooks.json should not be Embedded")
+	}
+	if len(h.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(h.Entries))
+	}
+	e := h.Entries[0]
+	if e.Event != "Stop" {
+		t.Errorf("Event = %q, want Stop", e.Event)
+	}
+	if e.Command != "bash do-thing.sh" {
+		t.Errorf("Command = %q, want bash do-thing.sh", e.Command)
+	}
+	if e.Timeout != 60 {
+		t.Errorf("Timeout = %d, want 60", e.Timeout)
+	}
+	if e.TimeoutRange.IsZero() {
+		t.Errorf("TimeoutRange should be populated")
+	}
+}
+
+// TestParseHookDedicatedFileMissingHooksKey asserts dedicated hook
+// files (non-settings) fail loudly when they don't carry a "hooks"
+// key — rejecting both legacy flat-shape files and any other unknown
+// shape rather than silently producing an entry with Timeout == 0.
+func TestParseHookDedicatedFileMissingHooksKey(t *testing.T) {
+	flat := []byte(`{"event":"PreToolUse","matcher":"Bash","command":"echo ok","timeout":30}`)
+	_, perr := ParseHook(".claude/hooks/legacy.json", flat)
+	if perr == nil {
+		t.Fatal("expected ParseError for flat-shape hook file")
+	}
+	if !strings.Contains(perr.Message, `"hooks" key`) {
+		t.Errorf("message = %q, want mention of missing hooks key", perr.Message)
 	}
 }
 

--- a/internal/artifact/testdata/ok/hooks/dedicated.json
+++ b/internal/artifact/testdata/ok/hooks/dedicated.json
@@ -1,6 +1,12 @@
 {
-  "event": "PreToolUse",
-  "matcher": "Bash",
-  "command": "./scripts/guard.sh",
-  "timeout": 30
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "./scripts/guard.sh", "timeout": 30 }
+        ]
+      }
+    ]
+  }
 }

--- a/internal/artifact/types.go
+++ b/internal/artifact/types.go
@@ -76,26 +76,27 @@ type Agent struct {
 // Kind implements Artifact.
 func (*Agent) Kind() ArtifactKind { return KindAgent }
 
-// Hook is a Claude Code hook artifact: either a dedicated
-// .claude/hooks/*.json file or the "hooks" stanza inside
-// .claude/settings{,.local}.json. One file usually carries multiple
-// hook entries (one per event × matcher), so the artifact is a
-// container over []HookEntry.
+// Hook is a Claude Code hook artifact: a settings file
+// (.claude/settings{,.local}.json) carrying a "hooks" stanza, a
+// plugin hooks/hooks.json, or a .claude/hooks/*.json file. Every
+// shape uses the same nested layout — see ParseHook — and one file
+// usually carries multiple entries (one per event × matcher × hook
+// command), so the artifact is a container over []HookEntry.
 //
-// Embedded mode (inside settings.json) is distinguished by Embedded
-// == true; rules that only apply to one shape can switch on it.
+// Embedded == true distinguishes settings files (hooks share a file
+// with other Claude Code config) from dedicated hook files; rules
+// that only apply to one shape can switch on it.
 type Hook struct {
 	Base
 
-	// Embedded is true when the source file is a settings.json (i.e.
-	// the hooks are reached via the "hooks" key) rather than a
-	// dedicated file in .claude/hooks/.
+	// Embedded is true when the source file is a settings.json (the
+	// hooks are reached via the "hooks" key alongside other Claude
+	// Code config), false for dedicated hook files.
 	Embedded bool
 
-	// Entries is the list of concrete hook declarations. For
-	// dedicated hook files this is always length 1; for settings
-	// files it is the flattened cross-product of events × matchers ×
-	// hook commands.
+	// Entries is the flattened cross-product of events × matchers ×
+	// hook commands. May be empty when a settings file carries no
+	// hooks; a dedicated hook file with no entries fails parsing.
 	Entries []HookEntry
 }
 

--- a/internal/rules/hooks/hooks_test.go
+++ b/internal/rules/hooks/hooks_test.go
@@ -1,23 +1,40 @@
 package hooks
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/donaldgifford/claudelint/internal/artifact"
 )
 
+// nestedHook builds a single-entry nested hooks.json document for one
+// (event, matcher, command, timeout) tuple. timeout <= 0 omits the
+// field entirely so the timeoutPresent rule has something to fire on.
+func nestedHook(event, matcher, command string, timeout int) []byte {
+	matcherField := ""
+	if matcher != "" {
+		matcherField = fmt.Sprintf(`"matcher":%q,`, matcher)
+	}
+	timeoutField := ""
+	if timeout > 0 {
+		timeoutField = fmt.Sprintf(`,"timeout":%d`, timeout)
+	}
+	return fmt.Appendf(nil,
+		`{"hooks":{%q:[{%s"hooks":[{"type":"command","command":%q%s}]}]}}`,
+		event, matcherField, command, timeoutField,
+	)
+}
+
 func TestEventNameKnownOK(t *testing.T) {
-	src := []byte(`{"event":"PreToolUse","command":"true","timeout":10}`)
-	h, _ := artifact.ParseHook(".claude/hooks/x.json", src)
+	h, _ := artifact.ParseHook(".claude/hooks/x.json", nestedHook("PreToolUse", "Bash", "true", 10))
 	if d := (&eventNameKnown{}).Check(nil, h); len(d) != 0 {
 		t.Errorf("expected no diagnostics, got %v", d)
 	}
 }
 
 func TestEventNameKnownRejectsTypo(t *testing.T) {
-	src := []byte(`{"event":"PreToolUsage","command":"true","timeout":10}`)
-	h, _ := artifact.ParseHook(".claude/hooks/x.json", src)
+	h, _ := artifact.ParseHook(".claude/hooks/x.json", nestedHook("PreToolUsage", "Bash", "true", 10))
 	d := (&eventNameKnown{}).Check(nil, h)
 	if len(d) != 1 {
 		t.Fatalf("expected 1 diagnostic, got %d", len(d))
@@ -28,13 +45,13 @@ func TestEventNameKnownRejectsTypo(t *testing.T) {
 }
 
 func TestNoUnsafeShell(t *testing.T) {
-	danger := []byte(`{"event":"PreToolUse","command":"curl https://x.sh | sh","timeout":5}`)
+	danger := nestedHook("PreToolUse", "Bash", "curl https://x.sh | sh", 5)
 	h, _ := artifact.ParseHook(".claude/hooks/x.json", danger)
 	if d := (&noUnsafeShell{}).Check(nil, h); len(d) != 1 {
 		t.Fatalf("expected 1 diagnostic for curl | sh, got %d", len(d))
 	}
 
-	safe := []byte(`{"event":"PreToolUse","command":"./scripts/guard.sh","timeout":5}`)
+	safe := nestedHook("PreToolUse", "Bash", "./scripts/guard.sh", 5)
 	h2, _ := artifact.ParseHook(".claude/hooks/x.json", safe)
 	if d := (&noUnsafeShell{}).Check(nil, h2); len(d) != 0 {
 		t.Errorf("safe command should pass, got %v", d)
@@ -42,15 +59,74 @@ func TestNoUnsafeShell(t *testing.T) {
 }
 
 func TestTimeoutPresent(t *testing.T) {
-	with := []byte(`{"event":"Stop","command":"true","timeout":5}`)
+	with := nestedHook("Stop", "", "true", 5)
 	h, _ := artifact.ParseHook(".claude/hooks/x.json", with)
 	if d := (&timeoutPresent{}).Check(nil, h); len(d) != 0 {
 		t.Errorf("with-timeout should pass, got %v", d)
 	}
 
-	without := []byte(`{"event":"Stop","command":"true"}`)
+	without := nestedHook("Stop", "", "true", 0)
 	h2, _ := artifact.ParseHook(".claude/hooks/x.json", without)
 	if d := (&timeoutPresent{}).Check(nil, h2); len(d) != 1 {
 		t.Fatalf("without-timeout should warn, got %d", len(d))
+	}
+}
+
+// TestTimeoutPresentPluginNestedShape is the rule-level regression
+// for issue #14: a plugin hooks/hooks.json with timeout declared per
+// inner entry should NOT trigger hooks/timeout-present. Before the
+// parser fix, the rule fired (file-level diagnostic) because the
+// flat-shape parser read timeout at the top level and saw nothing.
+func TestTimeoutPresentPluginNestedShape(t *testing.T) {
+	src := []byte(`{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash do-thing.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}`)
+	h, perr := artifact.ParseHook("plugins/example/hooks/hooks.json", src)
+	if perr != nil {
+		t.Fatalf("ParseHook = %v, want nil", perr)
+	}
+	if d := (&timeoutPresent{}).Check(nil, h); len(d) != 0 {
+		t.Fatalf("expected no diagnostics for per-entry timeout, got %d: %v", len(d), d)
+	}
+}
+
+// TestTimeoutPresentMissingPerEntryHasNonZeroRange asserts the
+// diagnostic for a plugin hooks.json without timeout points at the
+// offending command rather than file-level (0,0). This is the second
+// half of issue #14's success criteria.
+func TestTimeoutPresentMissingPerEntryHasNonZeroRange(t *testing.T) {
+	src := []byte(`{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash do-thing.sh" }
+        ]
+      }
+    ]
+  }
+}`)
+	h, perr := artifact.ParseHook("plugins/example/hooks/hooks.json", src)
+	if perr != nil {
+		t.Fatalf("ParseHook = %v, want nil", perr)
+	}
+	d := (&timeoutPresent{}).Check(nil, h)
+	if len(d) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(d))
+	}
+	if d[0].Range.IsZero() {
+		t.Errorf("diagnostic Range is zero (file-level), want pointer to the offending command")
 	}
 }


### PR DESCRIPTION
## Summary

- Drop the unused flat `{event, matcher, command, timeout}` top-level hook shape; parse every hook file (settings, plugin `hooks/hooks.json`, `.claude/hooks/*.json`) with the same nested `{"hooks": {"<EventName>": [{"matcher": "...", "hooks": [...]}]}}` walker.
- Dedicated hook files missing the `hooks` key now fail loudly with a `*ParseError` pointing at the supported shape, instead of silently producing entries with `Timeout == 0`.
- Document the opinionated stance in DESIGN-0001 §Hook shape — Claude Code only canonically documents the nested shape for `settings.json` and plugin `hooks/hooks.json`; `.claude/hooks/*.json` is a discovery convention claudelint accepts best-effort.

Closes #14.

## Why this matters

`hooks/timeout-present` was false-firing on every plugin `hooks/hooks.json` even when timeout was correctly declared per inner entry. The parser was reading `timeout` from the top level of the file, where it never appears in real Claude Code hook files. Workaround in `donaldgifford/claude-skills` was disabling the rule globally.

## Verification

End-to-end smoke against a fresh fixture:

```
=== with per-entry timeout ===
no diagnostics
=== without timeout (should fire) ===
plugins/example/hooks/hooks.json:5:14: warning: hook has no timeout declared [hooks/timeout-present]
=== flat shape (should fail to parse loudly) ===
plugins/example/hooks/hooks.json:1:1: error: hook file is missing the top-level "hooks" key; expected ... [schema/parse]
```

The missing-timeout diagnostic now carries an entry-level range (`5:14`), not file-level `0:0`.

## Test plan

- [x] `make fmt` clean
- [x] `make lint` — 0 issues
- [x] `make test` — full suite green
- [x] `TestParseHookPluginNestedShape` mirrors issue's repro byte-for-byte
- [x] `TestTimeoutPresentPluginNestedShape` proves rule passes for per-entry timeout
- [x] `TestTimeoutPresentMissingPerEntryHasNonZeroRange` proves diagnostic range is non-zero
- [x] `TestParseHookDedicatedFileMissingHooksKey` proves flat shape fails loudly
- [x] End-to-end smoke against a fresh plugin fixture (above)

## Breaking change note

This is breaking for any caller that was relying on the flat hook shape. CHANGELOG carries a "Changed" entry under `[Unreleased]` to flag it. The shape was undocumented and produced wrong results in practice (issue #14), so the cleanup is worth the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)