### PR TITLE
chore(deps): bundle dependabot action bumps

### DIFF
--- a/.github/workflows/changelog-regen.yml
+++ b/.github/workflows/changelog-regen.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
           egress-policy: audit
 
@@ -34,7 +34,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up mise (for git-cliff)
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           experimental: true
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           experimental: true
       - name: Generate fresh CHANGELOG

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Set up mise (for just)
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           experimental: true
 
@@ -130,7 +130,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Build and push dev image
         if: github.event_name == 'pull_request'
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7.1.0
         with:
           targets: ci
           source: .
@@ -150,7 +150,7 @@ jobs:
 
       - name: Build multi-arch images (post-merge validation)
         if: github.event_name == 'push'
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7.1.0
         with:
           targets: ci
           source: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -105,7 +105,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker images
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7.1.0
         with:
           targets: release
           source: .

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
 
       # ... such as the Code Scanning tab (https://github.com/oapi-codegen/oapi-codegen/security/code-scanning?query=is%3Aopen+branch%3Amain+tool%3Agovulncheck)
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@v4.35.5
         with:
           sarif_file: govulncheck.sarif
           category: govulncheck


### PR DESCRIPTION
## Summary

Bundles 5 open dependabot PRs (#26, #27, #28, #29, #30) into one merge to keep CI/release tooling current without 5 separate noisy merges.

| Action | From | To |
| --- | --- | --- |
| github/codeql-action | v4.35.1 | v4.35.5 |
| docker/login-action | v3 / v4 | v4.1.0 |
| jdx/mise-action | v3 | v4 |
| step-security/harden-runner | v2.18.0 (SHA-pinned) | v2.19.3 (SHA-pinned) |
| docker/bake-action | v6 | v7.1.0 |

Closes the 5 dependabot PRs once merged.

## Test plan

- [ ] CI green (lint, test, security, build, docker-build)
- [ ] Changelog drift check passes after auto-sync
- [ ] No release triggered (patch-only deps, but release workflow will run since this is on `main` after merge — the bumped Docker/mise/codeql actions are exercised by the docker + changelog-regen jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)