### PR TITLE
chore(security): SBOM generation + grype scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,58 @@
 ---
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+# Security-updates-only mode. Renovate owns routine version bumps
+# (per the `# renovate:` annotations in mise.toml, docker-bake.hcl,
+# etc.); Dependabot's only job here is the GitHub Advisory feed —
+# when GHAS flags a CVE in our dep tree, open a PR.
+#
+# `open-pull-requests-limit: 0` is the documented switch that disables
+# version updates while keeping security updates enabled:
+# https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
 version: 2
 updates:
-  # version updates: enabled
-  # security updates: enabled
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-  - package-ecosystem: "docker"
-    directory: "cicd"
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: "golang"
-        update-types: ["version-update:semver-major"]
-    cooldown:
-      default-days: 7
-  # version updates: disabled
-  # security updates: enabled
-  # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
+      interval: weekly
     open-pull-requests-limit: 0
-    cooldown:
-      default-days: 7
+    labels:
+      - security
+      - dependencies
+      - github_actions
+    assignees:
+      - donaldgifford
+    groups:
+      actions-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    labels:
+      - security
+      - dependencies
+      - docker
+    assignees:
+      - donaldgifford
+    groups:
+      docker-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    labels:
+      - security
+      - dependencies
+      - go
+    assignees:
+      - donaldgifford
+    groups:
+      gomod-security:
+        applies-to: security-updates
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Set up mise (for syft)
-        uses: jdx/mise-action@v4
-        with:
-          experimental: true
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
 
       - name: Build snapshot release with SBOMs
         uses: goreleaser/goreleaser-action@v7.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,23 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Verify builds for all platforms
+      - name: Set up mise (for syft)
+        uses: jdx/mise-action@v4
+        with:
+          experimental: true
+
+      - name: Build snapshot release with SBOMs
         uses: goreleaser/goreleaser-action@v7.1.0
         with:
           version: "~> v2"
-          args: build --snapshot --clean
+          args: release --snapshot --skip=publish --skip=sign --clean
+
+      - name: Scan archive SBOM
+        uses: anchore/scan-action@v7
+        with:
+          sbom: dist/claudelint_linux_amd64.tar.gz.spdx.json
+          severity-cutoff: high
+          fail-build: false
 
   docker-build:
     name: Docker Build
@@ -147,6 +159,14 @@ jobs:
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max
             *.output=type=registry
+
+      - name: Scan dev image
+        if: github.event_name == 'pull_request'
+        uses: anchore/scan-action@v7
+        with:
+          image: ghcr.io/donaldgifford/claudelint:dev-ci
+          severity-cutoff: high
+          fail-build: false
 
       - name: Build multi-arch images (post-merge validation)
         if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v6
 
@@ -117,11 +120,20 @@ jobs:
           args: release --snapshot --skip=publish --skip=sign --clean
 
       - name: Scan archive SBOM
+        id: scan-sbom
         uses: anchore/scan-action@v7
         with:
           sbom: dist/claudelint_linux_amd64.tar.gz.spdx.json
           severity-cutoff: high
           fail-build: false
+          output-format: sarif
+
+      - name: Upload SBOM scan SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4.35.5
+        with:
+          sarif_file: ${{ steps.scan-sbom.outputs.sarif }}
+          category: anchore-archive-sbom
 
   docker-build:
     name: Docker Build
@@ -129,6 +141,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - uses: actions/checkout@v6
 
@@ -159,12 +172,21 @@ jobs:
             *.output=type=registry
 
       - name: Scan dev image
+        id: scan-image
         if: github.event_name == 'pull_request'
         uses: anchore/scan-action@v7
         with:
           image: ghcr.io/donaldgifford/claudelint:dev-ci
           severity-cutoff: high
           fail-build: false
+          output-format: sarif
+
+      - name: Upload image scan SARIF
+        if: always() && github.event_name == 'pull_request'
+        uses: github/codeql-action/upload-sarif@v4.35.5
+        with:
+          sarif_file: ${{ steps.scan-image.outputs.sarif }}
+          category: anchore-dev-image
 
       - name: Build multi-arch images (post-merge validation)
         if: github.event_name == 'push'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+---
+# $schema=https://www.schemastore.org/github-action.json
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays at 0000 — same slot as security.yml's grype scan.
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4.35.5
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4.35.5
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4.35.5
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/dependabot-severity-label.yml
+++ b/.github/workflows/dependabot-severity-label.yml
@@ -1,0 +1,49 @@
+---
+# $schema=https://www.schemastore.org/github-action.json
+# Reads the severity out of a Dependabot security PR's body and applies
+# a matching `severity:<level>` label. Dependabot's body contains lines
+# like "[CVE-YYYY-NNNNN](url) (high severity)" — we grep for that.
+# Highest severity wins if multiple advisories are bundled.
+name: Label Dependabot Security Severity
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Detect severity from PR body
+        id: sev
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |-
+          if echo "$BODY" | grep -qiE '\(critical severity\)'; then
+            echo "level=critical" >>"$GITHUB_OUTPUT"
+          elif echo "$BODY" | grep -qiE '\(high severity\)'; then
+            echo "level=high" >>"$GITHUB_OUTPUT"
+          elif echo "$BODY" | grep -qiE '\(medium severity\)'; then
+            echo "level=medium" >>"$GITHUB_OUTPUT"
+          elif echo "$BODY" | grep -qiE '\(low severity\)'; then
+            echo "level=low" >>"$GITHUB_OUTPUT"
+          else
+            echo "level=" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply severity label
+        if: steps.sev.outputs.level != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          LEVEL: ${{ steps.sev.outputs.level }}
+        run: |-
+          gh pr edit "$PR_NUMBER" \
+            --add-label "severity:$LEVEL" \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
             docker-bake.hcl
             ${{ steps.meta.outputs.bake-file-tags }}
             ${{ steps.meta.outputs.bake-file-labels }}
+            ${{ steps.meta.outputs.bake-file-annotations }}
           set: |-
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,3 +28,26 @@ jobs:
         with:
           sarif_file: govulncheck.sarif
           category: govulncheck
+
+  scan-image:
+    name: Scan published image with anchore/grype
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Scan latest image
+        id: scan
+        uses: anchore/scan-action@v7
+        with:
+          image: ghcr.io/donaldgifford/claudelint:latest
+          severity-cutoff: high
+          fail-build: false
+          output-format: sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v4.35.5
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: anchore-image-scan
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,14 @@ archives:
     files:
       - none*
 
+sboms:
+  - id: archives
+    artifacts: archive
+    documents:
+      - "${artifact}.spdx.json"
+    cmd: syft
+    args: ["$artifact", "--output", "spdx-json=$document"]
+
 checksum:
   name_template: 'checksums.txt'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
+## [unreleased]
+
+### Bug Fixes
+
+- *(ci)* Install syft via anchore action, not mise
+
+### Miscellaneous Tasks
+
+- *(security)* Wire SBOM generation + grype scanning
+
 ## [0.2.1] - 2026-05-23
 
 ### Miscellaneous Tasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 ### Features
 
 - *(security)* Surface scan findings + GHCR OCI annotations
+- *(security)* Bump Go to 1.26.3 + add CodeQL workflow
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 ## [unreleased]
 
+### Features
+
+- *(security)* Surface scan findings + GHCR OCI annotations
+
 ### Bug Fixes
 
 - *(ci)* Install syft via anchore action, not mise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 ### Miscellaneous Tasks
 
 - *(security)* Wire SBOM generation + grype scanning
+- *(security)* Switch dependabot to security-only + severity labels
 
 ## [0.2.1] - 2026-05-23
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -77,6 +77,10 @@ target "claudelint-ci" {
   inherits  = ["_common"]
   tags      = ["${REGISTRY}:${TAG}-ci"]
   platforms = ["linux/amd64"]
+  attest = [
+    "type=sbom",
+    "type=provenance,mode=min",
+  ]
 }
 
 target "claudelint-release" {
@@ -88,4 +92,8 @@ target "claudelint-release" {
     "linux/arm64",
   ]
   output = ["type=registry"]
+  attest = [
+    "type=sbom",
+    "type=provenance,mode=max",
+  ]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -43,7 +43,17 @@ target "_common" {
     "org.opencontainers.image.source"      = "https://github.com/donaldgifford/claudelint"
     "org.opencontainers.image.licenses"    = "Apache-2.0"
     "org.opencontainers.image.description" = "claudelint"
+    "org.opencontainers.image.title"       = "claudelint"
   }
+  // Annotations land on the OCI manifest (and the index, for multi-arch
+  // builds). GHCR reads these — not labels — to populate the version
+  // page's source-repo link, description, and license badge.
+  annotations = [
+    "index,manifest:org.opencontainers.image.source=https://github.com/donaldgifford/claudelint",
+    "index,manifest:org.opencontainers.image.licenses=Apache-2.0",
+    "index,manifest:org.opencontainers.image.description=claudelint",
+    "index,manifest:org.opencontainers.image.title=claudelint",
+  ]
 }
 
 // Stub providing default `tags` for local `docker buildx bake`. CI

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/donaldgifford/claudelint
 
-go 1.26.1
+go 1.26.3
 
 require (
 	github.com/buger/jsonparser v1.1.2

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 
 # Go
 # renovate: datasource=github-tags depName=golang/go
-go = "1.26.1"
+go = "1.26.3"
 # renovate: datasource=github-releases depName=segmentio/golines
 golines = "latest"
 # renovate: datasource=go depName=github.com/spf13/cobra-cli


### PR DESCRIPTION
## Summary

Wires up SBOM generation, vulnerability scanning, source-code SAST, and splits Dependabot into security-only mode.

### SBOM + grype CVE scanning
- **goreleaser** emits `*.spdx.json` SBOMs alongside each archive (attached to GitHub releases).
- **docker-bake** uses BuildKit `attest = ["type=sbom", "type=provenance,mode=min|max"]` on `claudelint-ci` and `claudelint-release` — the SBOM ships as an OCI attestation alongside the image manifest.
- **ci.yml `build`** runs `goreleaser release --snapshot --skip=publish --skip=sign` (via `anchore/sbom-action/download-syft` rather than mise — mise shims tripped a config-trust error from goreleaser's cwd) and scans the archive SBOM with `anchore/scan-action`, uploading SARIF.
- **ci.yml `docker-build`** scans the pushed `:dev-ci` image ref with `anchore/scan-action`, uploading SARIF.
- **security.yml** replaces the broken `scan-sbom` job (referenced a never-created file) with a weekly + push-to-main scan of `ghcr.io/donaldgifford/claudelint:latest`.

### CodeQL source-code SAST
- New `.github/workflows/codeql.yml` runs Go analysis on PR, push to main, and weekly (Mon 00:00, same cron as security.yml).
- `queries: security-extended` for broader coverage than the default pack.
- SARIF lands in the same Security tab as grype.

### GHCR OCI annotations
- `docker-bake.hcl _common` now emits `annotations = [...]` with `index,manifest:` prefixes (multi-arch index + child manifests).
- `release.yml` passes `bake-file-annotations` to the bake step so metadata-action-derived annotations (revision, version, created) land on the published manifest.
- Net effect on GHCR: the version page links back to the repo with verified-build checkmark and shows the Apache-2.0 license badge.

### Go bump → clean CVE board
- `go.mod` + `mise.toml`: 1.26.1 → 1.26.3. Clears all 20 grype findings on this PR (1 critical, 11 high, 8 medium — every one was the same stdlib root cause).

### Dependabot split
- `dependabot.yml` rewritten: all three ecosystems now run in security-only mode (`open-pull-requests-limit: 0`). Renovate owns routine version bumps; Dependabot's job is the GitHub Advisory feed only.
- Fixed `docker` ecosystem directory `cicd` → `/` (Dockerfile is at repo root; old path was generating zero PRs).
- Each ecosystem grouped under `applies-to: security-updates`, auto-labeled (`security`, `dependencies`, `<ecosystem>`), and assigned to `@donaldgifford`.
- New `dependabot-severity-label.yml` workflow parses Dependabot PR bodies for the `(<level> severity)` line and applies `severity:critical|high|medium|low`. Highest severity wins when multiple advisories are bundled.
- Created four `severity:*` labels with standard GHAS-style colors.

## Verification

- [x] CI green (lint, test, security, build w/ SBOM scan, docker-build w/ image scan, CodeQL, grype virtual check)
- [x] `Scan archive SBOM` step passes against `dist/claudelint_linux_amd64.tar.gz.spdx.json`
- [x] `Scan dev image` step passes against `:dev-ci`
- [x] CodeQL `Analyze Go` step passes
- [x] SARIF uploads populate Security → Code scanning (verified via `gh api .../code-scanning/alerts`)
- [x] GHCR version page surfaces source-repo link + license badge (visible on `:dev-ci`)
- [x] `dependabot.yml` validates (Dependabot's own bot check on the PR went green)
- [x] All four `severity:*` labels exist
- [x] Zero open Code Scanning alerts on this PR after Go bump
- [ ] After merge, security.yml `scan-image` job uploads weekly SARIF
- [ ] After merge, CodeQL workflow runs on schedule
- [ ] Next release attaches `*.spdx.json` files to the GH release and pushes SBOM attestations to GHCR (verify with `docker buildx imagetools inspect ghcr.io/donaldgifford/claudelint:<tag> --format '{{ json .SBOM }}'`)
- [ ] First Dependabot security PR gets the `severity:*` label applied automatically

## Follow-ups (not in this PR)

- Configure branch protection on `main` to require `Code scanning results / Grype` and `Code scanning results / CodeQL` as required checks, with severity threshold set in Settings → Code security → Code scanning.
- Once a real release ships, GHCR's "Latest" badge will move off the dev-ci tag automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)