### PR TITLE
fix(release): install syft before goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
+## [unreleased]
+
+### Bug Fixes
+
+- *(release)* Install syft before running goreleaser
+
 ## [0.2.2] - 2026-05-30
 
 ### Miscellaneous Tasks


### PR DESCRIPTION
## Summary

The release job invokes goreleaser, which (post-#32) requires syft on PATH to generate per-archive SBOMs. ci.yml's `build` job installs syft via `anchore/sbom-action/download-syft@v0`; release.yml was missing the equivalent step. The v0.2.2 release run died at:

```
exec: "syft": executable file not found in $PATH
```

after `bump-version` had already created and pushed the `v0.2.2` tag — leaving an orphan tag with no GH release and no Docker image. ([run #26689445906](https://github.com/donaldgifford/claudelint/actions/runs/26689445906/job/78663181092))

Adds the missing `Install syft` step before `Import GPG key` in the `release` job.

Labeled `patch` so this cuts a clean `v0.2.3`. The orphan `v0.2.2` tag will be deleted after merge — nothing consumed it.

## Test plan

- [ ] CI green (lint, test, security, build, docker-build, codeql, grype)
- [ ] After merge: release workflow succeeds end-to-end on v0.2.3
- [ ] After merge: GH release v0.2.3 has `*.spdx.json` SBOMs attached
- [ ] After merge: `ghcr.io/donaldgifford/claudelint:0.2.3` exists with SBOM attestation
- [ ] After merge: delete orphan tag `v0.2.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)