### PR TITLE
docs(impl-0003): close out — production live at claudelint.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - *(docs)* Dual-output docs site — MkDocs (TechDocs) + Starlight (claudelint.dev) ([#40](https://github.com/donaldgifford/claudelint/issues/40))
 
+### Documentation
+
+- *(impl-0003)* Close out — production live at claudelint.dev
+
 ## [0.2.3] - 2026-05-30
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,12 +95,12 @@ Docs are managed by the `docz` CLI (config in `.docz.yaml`). Six doc types: `rfc
 
 Use `Skill` with the `docz:*` skills for doc lifecycle work rather than reinventing the frontmatter by hand.
 
-### Dual-output docs site (DESIGN-0003 / IMPL-0003 — in progress on `docs/site` branch)
+### Dual-output docs site (DESIGN-0003 / IMPL-0003 — shipped via PR #40; live at `https://claudelint.dev`)
 
 The same `docs/` tree feeds **two** rendered outputs:
 
 - **MkDocs + Material** — consumed by Backstage TechDocs. Driven by `mkdocs.yml`, which `docz update` keeps in sync. No CI changes.
-- **Astro + Starlight** — public site at `https://claudelint.dev` (Cloudflare Pages, planned cutover in Phase 6). Lives under `site/`; reads the shared root `docs/` tree via Astro content collections.
+- **Astro + Starlight** — public site at `https://claudelint.dev` (Cloudflare Pages; production tracks `main`, PRs get preview deploys + a `Cloudflare Pages` status check). Lives under `site/`; reads the shared root `docs/` tree via a `site/src/content/docs` symlink + Starlight's bundled `docsLoader()`. `Docs / Lint Markdown` and `Docs / Build Starlight` are required checks on `main`. Landing-page polish (hero, brand, sidebar reshape) is designed in DESIGN-0004 and not yet implemented.
 
 Authoring rules to keep both pipelines happy:
 

--- a/docs/design/0003-dual-output-docs-site-shared-source-mkdocs-for-techdocs.md
+++ b/docs/design/0003-dual-output-docs-site-shared-source-mkdocs-for-techdocs.md
@@ -1,7 +1,7 @@
 ---
 id: DESIGN-0003
 title: "Dual-output docs site — shared source, MkDocs for TechDocs, Starlight for public"
-status: Draft
+status: Implemented
 author: Donald Gifford
 created: 2026-05-31
 ---
@@ -9,7 +9,7 @@ created: 2026-05-31
 
 # DESIGN 0003: Dual-output docs site — shared source, MkDocs for TechDocs, Starlight for public
 
-**Status:** Draft
+**Status:** Implemented
 **Author:** Donald Gifford
 **Date:** 2026-05-31
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -41,6 +41,6 @@ docz create design "Your Design Title"
 |----|-------|--------|------|--------|------|
 | DESIGN-0001 | Claudelint linter architecture and rule engine | Draft | 2026-04-18 | Donald Gifford | [0001-claudelint-linter-architecture-and-rule-engine.md](0001-claudelint-linter-architecture-and-rule-engine.md) |
 | DESIGN-0002 | Phase 2 — marketplaces, MCP rules, and GitHub Action | Draft | 2026-04-23 | Donald Gifford | [0002-phase-2-marketplaces-mcp-rules-and-github-action.md](0002-phase-2-marketplaces-mcp-rules-and-github-action.md) |
-| DESIGN-0003 | Dual-output docs site — shared source, MkDocs for TechDocs, Starlight for public | Draft | 2026-05-31 | Donald Gifford | [0003-dual-output-docs-site-shared-source-mkdocs-for-techdocs.md](0003-dual-output-docs-site-shared-source-mkdocs-for-techdocs.md) |
+| DESIGN-0003 | Dual-output docs site — shared source, MkDocs for TechDocs, Starlight for public | Implemented | 2026-05-31 | Donald Gifford | [0003-dual-output-docs-site-shared-source-mkdocs-for-techdocs.md](0003-dual-output-docs-site-shared-source-mkdocs-for-techdocs.md) |
 | DESIGN-0004 | Starlight landing page polish and brand pass | Draft | 2026-06-08 | Donald Gifford | [0004-starlight-landing-page-polish-and-brand-pass.md](0004-starlight-landing-page-polish-and-brand-pass.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/impl/0003-phase-3-dual-output-docs-site-with-starlight.md
+++ b/docs/impl/0003-phase-3-dual-output-docs-site-with-starlight.md
@@ -1,7 +1,7 @@
 ---
 id: IMPL-0003
 title: "Phase 3 — Dual-output docs site with Starlight"
-status: In Progress
+status: Completed
 author: Donald Gifford
 created: 2026-05-31
 ---
@@ -10,7 +10,7 @@ created: 2026-05-31
 
 # IMPL 0003: Phase 3 — Dual-output docs site with Starlight
 
-**Status:** Draft **Author:** Donald Gifford **Date:** 2026-05-31
+**Status:** Completed **Author:** Donald Gifford **Date:** 2026-05-31
 
 <!--toc:start-->
 - [Objective](#objective)
@@ -264,10 +264,13 @@ two clean PRs.
       _(separate `lint-md` job running `just lint-md`)_
 - [x] Also: extend `.github/labeler.yml` so PRs touching `site/**` get the
       `documentation` label.
-- [ ] First-pass: do **not** add to branch protection. Observe two PRs running
-      clean.
-- [ ] After two clean runs: add `Docs / build` (or chosen job name) as a
-      required status check.
+- [x] First-pass: do **not** add to branch protection. Observe two PRs running
+      clean. _(superseded — Donald promoted the checks directly after PR #40's
+      clean run rather than waiting for a second PR)_
+- [x] After two clean runs: add `Docs / build` (or chosen job name) as a
+      required status check. _(done — `Docs / Lint Markdown` +
+      `Docs / Build Starlight` added to `main` branch protection via the
+      dashboard, per PR #40's task list)_
 - [x] Update CLAUDE.md "Git / PR conventions" section to mention the docs check.
       _(added in 6fdacb2 — `Docs CI` bullet in CLAUDE.md L126)_
 
@@ -304,17 +307,17 @@ not yet at `claudelint.dev`.
       `cd site && npm install && npm run build`, build output directory =
       `site/dist`, root directory = repo root. _(working — preview builds
       succeed and serve the full site)_
-- [ ] Set Node version env var in Cloudflare Pages to match `mise.toml` Node pin
-      (currently `22.20.0`). _(builds pass on Cloudflare's default Node; confirm
-      the pin in dashboard settings so a future default-bump can't break us)_
-- [ ] Set production branch to `main`. _(confirm in dashboard; unverifiable
-      from the repo until the first post-merge deploy)_
+- [x] Set Node version env var in Cloudflare Pages to match `mise.toml` Node pin
+      (currently `22.20.0`). _(set via dashboard, per PR #40's task list)_
+- [x] Set production branch to `main`. _(confirmed — the post-merge production
+      deploy fired off PR #40's merge commit)_
 - [x] Enable preview deployments for all branches with open PRs. _(working —
       per-commit preview URLs like `115f2e1f.claudelint.pages.dev` plus the
       `docs-site.claudelint.pages.dev` branch alias)_
-- [ ] Trigger first deploy by pushing a no-op to `main` (or by manually
-      deploying); verify the Pages-assigned subdomain works. _(fires
-      automatically when PR #40 merges)_
+- [x] Trigger first deploy by pushing a no-op to `main` (or by manually
+      deploying); verify the Pages-assigned subdomain works. _(fired off PR
+      #40's merge — `claudelint.pages.dev` and `claudelint.dev` both serve
+      200, verified 2026-07-09)_
 - [x] Open a test PR that touches a doc; verify Cloudflare Pages auto-comments
       with the preview URL. _(PR #40 itself — the `Cloudflare Pages` status
       check carries the deploy link)_
@@ -347,14 +350,16 @@ dual-pipeline setup.
 
 #### Tasks
 
-- [ ] In Cloudflare DNS for `claudelint.dev`: add the Pages project as a custom
-      domain (Cloudflare handles cert provisioning automatically). _(blocked on
-      Phase 5 + dashboard access)_
-- [ ] Verify `https://claudelint.dev` resolves to the Starlight site with a
-      valid cert. _(blocked on Phase 5)_
+- [x] In Cloudflare DNS for `claudelint.dev`: add the Pages project as a custom
+      domain (Cloudflare handles cert provisioning automatically). _(done via
+      dashboard, per PR #40's task list)_
+- [x] Verify `https://claudelint.dev` resolves to the Starlight site with a
+      valid cert. _(verified 2026-07-09 after PR #40 merged — site, Pagefind,
+      rules reference, and in-site changelog all serve 200 over HTTPS)_
 - [ ] Test redirect behavior: HTTP → HTTPS, `www.claudelint.dev` →
-      `claudelint.dev` (or whichever direction you prefer). _(blocked on
-      Phase 5)_
+      `claudelint.dev` (or whichever direction you prefer). _(HTTP→HTTPS works;
+      `www.claudelint.dev` has **no DNS record** as of 2026-07-09 — Donald to
+      decide whether to add a www → apex redirect or leave www unresolvable)_
 - [x] Confirm `mkdocs build --strict` still passes against current `docs/`.
       _(passes via new `just docs-mkdocs-check` recipe — runs
       `mkdocs build --strict -d build/mkdocs` via uvx; fixed one pre-existing
@@ -375,10 +380,14 @@ dual-pipeline setup.
       recipe, the dual-output design pointer, and a note that the markdown lint
       config enforces CommonMark.
 - [x] Update IMPL-0003 phase checkboxes as work completes; flip status to
-      "Implemented" when all phases are done. _(checkboxes current; final status
-      flip waits on Phase 5)_
-- [ ] Move DESIGN-0003 status from "Draft" → "Implemented". _(waits on Phase 5 —
-      code side complete, deploy pending)_
+      "Implemented" when all phases are done. _(status flipped to Completed
+      2026-07-09 after the production deploy verified. Two items remain open
+      by design: the Mermaid parity check (deferred until the first Mermaid
+      block lands — neither pipeline has the plugin wired) and the
+      www-redirect decision + optional Cloudflare API secrets (Donald's
+      call). Landing-page polish continues in DESIGN-0004.)_
+- [x] Move DESIGN-0003 status from "Draft" → "Implemented". _(flipped
+      2026-07-09 alongside this doc's status)_
 
 #### Success Criteria
 

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -41,5 +41,5 @@ docz create impl "Your Implementation Title"
 |----|-------|--------|------|--------|------|
 | IMPL-0001 | Phase 1: core linter for CLAUDE.md, skills, plugins, and hooks | Draft | 2026-04-18 | Donald Gifford | [0001-phase-1-core-linter-for-claudemd-skills-plugins-and-hooks.md](0001-phase-1-core-linter-for-claudemd-skills-plugins-and-hooks.md) |
 | IMPL-0002 | Phase 2 — marketplaces, MCP rules, SARIF, and GitHub Action | Draft | 2026-04-23 | Donald Gifford | [0002-phase-2-marketplaces-mcp-rules-sarif-and-github-action.md](0002-phase-2-marketplaces-mcp-rules-sarif-and-github-action.md) |
-| IMPL-0003 | Phase 3 — Dual-output docs site with Starlight | In Progress | 2026-05-31 | Donald Gifford | [0003-phase-3-dual-output-docs-site-with-starlight.md](0003-phase-3-dual-output-docs-site-with-starlight.md) |
+| IMPL-0003 | Phase 3 — Dual-output docs site with Starlight | Completed | 2026-05-31 | Donald Gifford | [0003-phase-3-dual-output-docs-site-with-starlight.md](0003-phase-3-dual-output-docs-site-with-starlight.md) |
 <!-- END DOCZ AUTO-GENERATED -->


### PR DESCRIPTION
Closes out [IMPL-0003](docs/impl/0003-phase-3-dual-output-docs-site-with-starlight.md) following the merge of #40 and the first verified production deploy.

## Verified (2026-07-09)

- `https://claudelint.dev` serves the Starlight site over HTTPS (valid cert); HTTP 301s to HTTPS.
- Pagefind (`/pagefind/pagefind.js`), the rules reference, and the in-site changelog all serve 200 in production.
- No release tag was cut by the #40 merge (`dont-release` respected).
- `chore(changelog): Auto-sync` landed on `main` post-merge as designed.

## Changes

- IMPL-0003: checked off the verified Phase 4/5/6 tasks (branch-protection promotion, Node pin, production branch, first production deploy, custom domain + cert); status `In Progress` → `Completed`.
- DESIGN-0003: status `Draft` → `Implemented`.
- CLAUDE.md: docs-site section reframed from "in progress" to shipped; records the symlink + `docsLoader()` wiring, required checks, and the DESIGN-0004 pointer.
- `docz update` index refresh + changelog regen.

## Still open (tracked in IMPL-0003 annotations, not blockers)

- [ ] www redirect: `www.claudelint.dev` has **no DNS record** — decide add-redirect vs leave unresolvable (Donald, Cloudflare dashboard).
- [ ] Optional `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN` repo secrets (only needed if we ever want a custom deploy workflow).
- [ ] Mermaid parity check — deferred until the first Mermaid block lands; neither pipeline has the plugin wired yet.

Next docs work: [DESIGN-0004](docs/design/0004-starlight-landing-page-polish-and-brand-pass.md) (hero + CardGrid landing page, brand pass, sidebar reshape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)