### PR TITLE
docs: INV-0006 rule coverage audit + IMPL-0004 implementation tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - *(impl-0003)* Close out — production live at claudelint.dev ([#51](https://github.com/donaldgifford/claudelint/issues/51))
 - *(inv)* INV-0006 — rule coverage audit vs current Claude Code docs
+- *(inv)* Restructure INV-0006 into per-kind audit tables
 
 ## [0.2.3] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - *(impl-0003)* Close out — production live at claudelint.dev ([#51](https://github.com/donaldgifford/claudelint/issues/51))
 - *(inv)* INV-0006 — rule coverage audit vs current Claude Code docs
 - *(inv)* Restructure INV-0006 into per-kind audit tables
+- *(inv)* Promote all backlog rules into the three phased PRs
 
 ## [0.2.3] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - *(inv)* Restructure INV-0006 into per-kind audit tables
 - *(inv)* Promote all backlog rules into the three phased PRs
 - *(impl)* IMPL-0004 — ruleset alignment and agent rules
+- *(impl-0004)* Resolve all eight open questions on option (a)
 
 ## [0.2.3] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 - *(inv)* INV-0006 — rule coverage audit vs current Claude Code docs
 - *(inv)* Restructure INV-0006 into per-kind audit tables
 - *(inv)* Promote all backlog rules into the three phased PRs
+- *(impl)* IMPL-0004 — ruleset alignment and agent rules
 
 ## [0.2.3] - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 ### Documentation
 
 - *(impl-0003)* Close out — production live at claudelint.dev ([#51](https://github.com/donaldgifford/claudelint/issues/51))
+- *(inv)* INV-0006 — rule coverage audit vs current Claude Code docs
 
 ## [0.2.3] - 2026-05-30
 

--- a/docs/impl/0004-phase-4-ruleset-alignment-and-agent-rules.md
+++ b/docs/impl/0004-phase-4-ruleset-alignment-and-agent-rules.md
@@ -37,7 +37,7 @@ created: 2026-07-09
 - [File Changes](#file-changes)
 - [Testing Plan](#testing-plan)
 - [Dependencies](#dependencies)
-- [Open Questions](#open-questions)
+- [Resolved Decisions](#resolved-decisions)
 - [References](#references)
 <!--toc:end-->
 
@@ -406,110 +406,43 @@ proposed tables. One PR, minor release, fingerprint bump.
   re-verify the event list and enum values at Phase 1 build time in case
   the docs have moved again.
 
-## Open Questions
+## Resolved Decisions
 
-Answer format: **a** is the recommendation; later letters are
-alternatives; reply "other: ..." for anything else.
+All Open Questions resolved 2026-07-10 — every one on option (a), the
+recommendation. Task references like "(per OQ1 decision)" point here.
 
-**OQ1 — `.mcp.json` `servers` key deprecation path.** The parser reads
-`servers` today; the docs standardized on `mcpServers`.
-
-- a) Accept both; `mcpServers` wins when both present; emit an info
-  diagnostic on `servers` ("deprecated key; rename to mcpServers");
-  drop `servers` support at the next major ruleset rev. *(Recommended:
-  zero breakage for existing users including our own DESIGN-0002-era
-  fixtures, loud nudge, clean exit path.)*
-- b) Accept both silently, indefinitely; no diagnostic.
-- c) Hard-switch to `mcpServers` only; `servers` files get a parse-level
-  warning and lint as empty.
-
-**OQ2 — skill `name`/`description` requiredness in
-`schema/frontmatter-required`.** Docs: `name` optional (defaults to the
-directory name), `description` recommended (falls back to the first body
-paragraph).
-
-- a) Keep both required at current severity but reword diagnostics to
-  best-practice phrasing ("skills should declare X — Claude Code falls
-  back to Y"), and document the stricter-than-spec stance in rules.md.
-  *(Recommended: description quality is the entire trigger mechanism;
-  an explicit name costs nothing and helps marketplace review.)*
-- b) Keep `description` required; drop the `name` requirement to match
-  spec.
-- c) Downgrade both to warning severity, behavior otherwise unchanged.
-- d) Match spec exactly: drop `name`, make `description` a warning.
-
-**OQ3 — `plugin/manifest-fields` `version` requirement.** Docs require
-only `name`; a missing `version` falls back to git-SHA versioning.
-
-- a) Keep requiring `version` at error and document it as
-  stricter-by-design (marketplace-quality stance: pinned versions make
-  update semantics explicit). *(Recommended.)*
-- b) Downgrade the missing-`version` half to warning; keep `name` at
-  error.
-- c) Match spec: require `name` only.
-
-**OQ4 — opt-in mechanism for governance rules (`agents/model-policy`).**
-The `mcp/server-allowlist` pattern (default-enabled, nil option → loud
-config error) fits security rules but not governance rules; CLAUDE.md
-says revisit when a second rule needs opt-in — this is that rule.
-
-- a) Config-driven enable: a rule may declare itself opt-in; the engine
-  runs it only when `.claudelint.hcl` has a `rule` block for it. No
-  block → rule fully skipped and shown as "opt-in, disabled" in
-  `claudelint rules`. `mcp/server-allowlist` migrates to the same
-  mechanism (its loud-error-when-unconfigured behavior becomes
-  unreachable by default but is preserved for explicit enables without
-  an allowlist). *(Recommended: one clear convention, no per-rule
-  hacks, discoverable in the catalog.)*
-- b) Documented silent no-op inside the rule when its option is unset —
-  no engine change, cheapest, but invisible in the catalog and
-  inconsistent with `mcp/server-allowlist`.
-- c) Follow the `server-allowlist` precedent exactly: default-enabled,
-  loud config error when unconfigured. (Every unconfigured repo yells
-  about every agent — rejected by INV-0006's analysis but listed for
-  completeness.)
-
-**OQ5 — marketplace `owner` vs `author` alignment.** Docs: root
-`owner{name}` is required; `author` exists only on plugin entries.
-
-- a) Repurpose `marketplace/author-required` into
-  `marketplace/owner-required` checking root `owner.name` at warning
-  severity (rule-ID rename — the fingerprint is bumping anyway); legacy
-  `author` satisfies the check with an info-level "rename to owner"
-  hint. *(Recommended.)*
-- b) Keep `author-required` as-is (info) and add a separate
-  `marketplace/owner-required` (warning) — two rules, no rename.
-- c) Leave everything as today; note the divergence in rules.md only.
-
-**OQ6 — release cadence for the three code PRs.**
-
-- a) Each code PR ships as its own minor release via the label-driven
-  flow; the ruleset version bumps minor each time. *(Recommended: keeps
-  fingerprints, changelogs, and dogfood feedback loops small.)*
-- b) Land Phases 1–2 and 4 on a long-lived branch and ship one combined
-  minor together with Phase 5.
-
-**OQ7 — where `allowed-tools` validation lives after the skills/commands
-merge.**
-
-- a) Extend `commands/allowed-tools-known` `AppliesTo` to
-  `command, skill` and keep the existing rule ID — no config breakage
-  for current users; rules.md notes it covers both kinds.
-  *(Recommended.)*
-- b) New sibling rule `skills/allowed-tools-known` sharing the
-  implementation — cleaner naming, one more catalog entry.
-- c) Rename to a kind-neutral `schema/allowed-tools-known` — cleanest
-  naming, but breaks existing rule-ID references in user configs.
-
-**OQ8 — `hooks/timeout-present` disposition given the documented 600 s
-default timeout.**
-
-- a) Keep at warning with a rewritten message ("no explicit timeout;
-  Claude Code defaults to 600 s — declare one to fail faster in CI").
-  *(Recommended: explicit timeouts remain a real best practice for
-  plugin/marketplace review, claudelint's core audience.)*
-- b) Downgrade to info.
-- c) Retire the rule.
+- **OQ1 — `.mcp.json` `servers` key**: accept both keys; `mcpServers`
+  wins when both present; info diagnostic on `servers` ("deprecated key;
+  rename to mcpServers"); drop `servers` support at the next major
+  ruleset rev.
+- **OQ2 — skill `name`/`description` requiredness**: keep both required
+  at current severity; reword diagnostics to best-practice phrasing
+  ("skills should declare X — Claude Code falls back to Y"); document
+  the stricter-than-spec stance in rules.md.
+- **OQ3 — plugin `version` requirement**: keep requiring `version` at
+  error; document as stricter-by-design (pinned versions make update
+  semantics explicit for marketplace review).
+- **OQ4 — opt-in mechanism**: engine-level config-driven enable. A rule
+  may declare itself opt-in; the engine runs it only when
+  `.claudelint.hcl` has a `rule` block for it; no block → fully skipped
+  and shown as "opt-in, disabled" in `claudelint rules`.
+  `mcp/server-allowlist` migrates to the same mechanism (its
+  loud-error-when-unconfigured behavior preserved for explicit enables
+  without an allowlist). Details specified in DESIGN-0005 (Phase 3);
+  CLAUDE.md convention note updated there.
+- **OQ5 — marketplace `owner` vs `author`**: repurpose
+  `marketplace/author-required` into `marketplace/owner-required`
+  checking root `owner.name` at warning severity (rule-ID rename rides
+  the fingerprint bump); legacy `author` satisfies the check with an
+  info-level "rename to owner" hint.
+- **OQ6 — release cadence**: each code PR ships as its own minor release
+  via the label-driven flow; ruleset version bumps minor each time.
+- **OQ7 — `allowed-tools` rule placement**: extend
+  `commands/allowed-tools-known` `AppliesTo` to `command, skill`; keep
+  the existing rule ID; rules.md notes it covers both kinds.
+- **OQ8 — `hooks/timeout-present`**: keep at warning with a rewritten
+  message ("no explicit timeout; Claude Code defaults to 600 s —
+  declare one to fail faster in CI").
 
 ## References
 

--- a/docs/impl/0004-phase-4-ruleset-alignment-and-agent-rules.md
+++ b/docs/impl/0004-phase-4-ruleset-alignment-and-agent-rules.md
@@ -1,0 +1,528 @@
+---
+id: IMPL-0004
+title: "Phase 4 - Ruleset alignment and agent rules"
+status: Draft
+author: Donald Gifford
+created: 2026-07-09
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# IMPL 0004: Phase 4 - Ruleset alignment and agent rules
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-07-09
+
+<!--toc:start-->
+- [Objective](#objective)
+- [Scope](#scope)
+  - [In Scope](#in-scope)
+  - [Out of Scope](#out-of-scope)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 1 — Parser foundations](#phase-1--parser-foundations)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 2 — Correctness rule fixes](#phase-2--correctness-rule-fixes)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 3 — DESIGN-0005 for the agent package and opt-in mechanism](#phase-3--design-0005-for-the-agent-package-and-opt-in-mechanism)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+  - [Phase 4 — Agent rule package](#phase-4--agent-rule-package)
+    - [Tasks](#tasks-3)
+    - [Success Criteria](#success-criteria-3)
+  - [Phase 5 — Policy and remaining validation rules](#phase-5--policy-and-remaining-validation-rules)
+    - [Tasks](#tasks-4)
+    - [Success Criteria](#success-criteria-4)
+- [File Changes](#file-changes)
+- [Testing Plan](#testing-plan)
+- [Dependencies](#dependencies)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Objective
+
+Close the drift found in
+[INV-0006](../investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md):
+fix the four rules that produce wrong results against doc-valid input, update
+the seven that have stale premises, extend the parsers that block those fixes,
+and ship the agent rule package (including `model` validation and the opt-in
+`model-policy` enforcement rule). At completion the ruleset validates every
+artifact kind against the Claude Code docs as of 2026-07-09 (version markers
+through v2.1.205).
+
+**Implements:** INV-0006 Recommendation (PR 1 → Phases 1–2, PR 2 → Phases 3–4,
+PR 3 → Phase 5).
+
+## Scope
+
+### In Scope
+
+- Parser changes: `.mcp.json` `mcpServers` key + transport fields,
+  marketplace object sources, hook `type` + per-type fields, comma/space
+  splitting for tool lists, agent frontmatter field extension.
+- `KnownTools` and `KnownHookEvents` refresh.
+- Fixes/updates to the 11 existing rules marked Fix/Update in INV-0006.
+- New rules: `mcp/url-required` plus the agent package
+  (`agents/model-valid`, `agents/name-format`, `agents/tools-known`,
+  `agents/plugin-ignored-fields`, `agents/field-enums`) and the Phase 5
+  batch (`agents/model-policy`, `hooks/type-known`, `hooks/type-fields`,
+  `mcp/transport-known`, `mcp/no-secrets-in-headers`, `mcp/timeout-minimum`,
+  `marketplace/reserved-name`, `marketplace/name-format`,
+  `marketplace/source-path-safety`, `marketplace/renames-valid`,
+  `skills/description-length`, `skills/fork-agent-pairing`,
+  `claude_md/import-exists`).
+- DESIGN-0005 covering the agent package and the opt-in rule mechanism.
+- Ruleset version + fingerprint bumps per phase; `docs/rules/rules.md` and
+  README anchors updated alongside each rule change.
+- One dogfood pass against `donaldgifford/claude-skills` per shipped PR.
+
+### Out of Scope
+
+- Experimental surfaces: monitors, themes, LSP servers, `userConfig` schema
+  validation (docs mark these unstable; INV-0006 "deliberately not chasing
+  yet").
+- Path-scoped rule files (`.claude/rules/*.md`) as a ninth artifact kind.
+- `convert` subcommand (original Phase 3 plan, still gated on INV-0001).
+- Any engine-level scheduling/discovery changes beyond what the opt-in
+  mechanism decision (OQ4) requires.
+
+---
+
+## Implementation Phases
+
+Phases 1+2 ship together as one PR/release; Phase 4 and Phase 5 are one
+PR/release each. Phase 3 is a docs-only PR. Every code phase follows the
+house rule-change checklist: rule file + table-driven tests + `Register()` +
+`rules.DefaultHelpURI` anchor in README + `docs/rules/rules.md` entry +
+fingerprint guardrail acknowledgment + coverage-gate floor (55% per
+`internal/` package).
+
+---
+
+### Phase 1 — Parser foundations
+
+Extend the artifact layer so the rule layer can see what the docs define.
+No rule behavior changes in this phase beyond what parsing unlocks; all
+new fields carry ranges per the range-emission conventions (pre-parsed
+field ranges preferred).
+
+#### Tasks
+
+- [ ] `ParseMCPFile`: accept `mcpServers` as the primary top-level key;
+      keep `servers` accepted but tag the artifact so a deprecation
+      diagnostic can fire (per OQ1 decision).
+- [ ] `MCPServer` type: parse `type` (default `stdio`), `url`, `headers`
+      (string map), `headersHelper`, `timeout` (number, ms), `alwaysLoad`;
+      add ranges for `type` and `url`. `oauth{}` parsed as present/absent
+      only (no field validation this phase).
+- [ ] `ParseMarketplace`: parse `source` as string **or** object; model the
+      four documented object shapes (`github{repo,ref,sha}`,
+      `url{url,ref,sha}`, `git-subdir{url,path,ref,sha}`,
+      `npm{package,version,registry}`) into a typed `MarketplaceSource`
+      with a `Kind` discriminator; keep `Resolved` semantics for local
+      string paths.
+- [ ] `ParseMarketplace`: parse root `owner{name,email}` as a distinct
+      field (today folded into `Author`); parse `renames{}` map (for
+      Phase 5).
+- [ ] `ParseHook`: parse `type` (default `command` when absent), `url`,
+      `server`, `tool`, `prompt`, `args` (presence = exec-form), `async`,
+      and `shell` per hook entry; keep `command`/`timeout`/`matcher`
+      extraction as-is.
+- [ ] Tool-list splitting: new shared helper that accepts YAML list, or
+      comma/whitespace-separated string, and returns entries — used by
+      command/skill `allowed-tools`, `disallowed-tools`, and agent
+      `tools`/`disallowedTools`. Entries preserve permission-rule syntax
+      (`Bash(git add:*)`) and `mcp__*` patterns as single tokens.
+- [ ] `KnownTools`: add `Agent`, `Skill`; keep `Task` (documented alias);
+      add a helper that classifies `mcp__<server>`, `mcp__<server>__*`,
+      `Agent(...)`, and `Tool(args)` permission-rule forms as
+      structurally-valid rather than unknown.
+- [ ] `KnownHookEvents`: expand to the full documented event set
+      (~29 events; exact list + exact casing from the hooks reference,
+      recorded in a table in the rules doc).
+- [ ] `ParseSkill`/`ParseCommand`: parse `when_to_use`, `model` (command),
+      `context`, `agent`, `disable-model-invocation`, `user-invocable`,
+      `disallowed-tools` — fields needed by Phases 2 and 5.
+- [ ] Fixture sweep: add doc-valid testdata files exercising every new
+      shape (an `mcpServers` file with `http` + `stdio` servers, a
+      marketplace with all four object source types, a hooks file using
+      new events and all five hook types, skills/commands with
+      string-form `allowed-tools`).
+
+#### Success Criteria
+
+- All new fields parse with correct values and ranges in unit tests.
+- The doc-valid fixtures parse with **zero** `schema/parse` errors.
+- Existing fixtures still parse identically (no behavior change for old
+  shapes except the `servers`-key tagging).
+- `just check` green; coverage floor holds for `internal/artifact`.
+
+---
+
+### Phase 2 — Correctness rule fixes
+
+Fix the four wrong-today rules, adjust the Update-verdict rules, and add
+`mcp/url-required`. Ships with Phase 1 as one PR (ruleset minor bump,
+fingerprint change).
+
+#### Tasks
+
+- [ ] `hooks/event-name-known`: validate against the expanded event list;
+      diagnostic suggests the nearest known event on likely typos
+      (case-insensitive match).
+- [ ] `commands/allowed-tools-known`: consume the shared splitter; accept
+      permission-rule and `mcp__*` forms; extend `AppliesTo` to run on
+      skill `allowed-tools`/`disallowed-tools` too (per OQ7 decision).
+- [ ] `mcp/command-required`: fire only when `type` is `stdio` (or absent).
+- [ ] New `mcp/url-required` (schema/error): `http`/`sse`/`ws` transports
+      must declare a non-empty `url`.
+- [ ] `mcp/command-exists-on-path`: skip non-stdio transports.
+- [ ] `marketplace/plugin-source-valid`: object sources validate per-type
+      required fields (`repo` / `url` / `url`+`path` / `package`); string
+      sources keep the non-empty check; `sha` when present must be a
+      40-char hex string.
+- [ ] `marketplace/external-source-skipped`: rework — object sources are
+      now structured; the info diagnostic applies only to sources whose
+      content genuinely can't be checked locally.
+- [ ] `marketplace/version-semver`: split — missing root `version` → info;
+      present-but-not-semver → error.
+- [ ] `marketplace/author-required`: align with documented required
+      `owner{name}` (per OQ5 decision).
+- [ ] Deprecation diagnostic for the legacy `servers` key in `.mcp.json`
+      (synthesized like `schema/parse` or a dedicated rule — pick during
+      build) (per OQ1 decision).
+- [ ] `hooks/timeout-present`: reword message + rules.md entry around the
+      documented 600 s default (severity per OQ8 decision).
+- [ ] `hooks/no-unsafe-shell`: skip exec-form entries (`args` present) and
+      non-`command` hook types.
+- [ ] `schema/frontmatter-required`: reword skill diagnostics to
+      best-practice phrasing without changing behavior (per OQ2 decision).
+- [ ] `skills/no-version-field` + `plugin/manifest-fields`: help-text
+      updates citing the current docs (stricter-than-spec note for plugin
+      `version`, per OQ3 decision).
+- [ ] Ruleset version bump + fingerprint ack; `docs/rules/rules.md` +
+      README rule anchors updated for every touched rule.
+- [ ] Update DESIGN-0002 §2.2 (`servers` vs `mcpServers`) to record the
+      resolution; cross-link INV-0006.
+- [ ] Dogfood: run against a `donaldgifford/claude-skills` checkout and
+      the claudelint repo itself (`just self-check`); triage every
+      new/changed diagnostic.
+
+#### Success Criteria
+
+- The Phase 1 doc-valid fixtures lint with zero false positives
+  (previously: `mcpServers` files invisible, object sources erroring,
+  comma-form `allowed-tools` erroring, new hook events erroring).
+- Regression fixtures prove old invalid inputs still flag (unknown tool,
+  unknown event, missing stdio command, empty source).
+- `claudelint rules --json` reflects the new catalog; fingerprint
+  guardrail test updated deliberately.
+- Dogfood passes clean or with only agreed-expected diagnostics.
+- `just ci` green; release ships as a minor via the label-driven flow.
+
+---
+
+### Phase 3 — DESIGN-0005 for the agent package and opt-in mechanism
+
+Docs-only gate before the agent code. Small by design — INV-0006 already
+contains the research; the DESIGN settles the contested mechanics.
+
+#### Tasks
+
+- [ ] `docz create design` → DESIGN-0005 "Agent rules and opt-in rule
+      mechanism".
+- [ ] Specify the extended `Agent` artifact model (which of the 16
+      documented fields are parsed, their types/ranges; which are noted
+      but unparsed).
+- [ ] Specify each Phase 4 rule: id, category, severity, options,
+      diagnostics, range targets, and the shared model-value validator
+      reused by skill/command `model` (values: `sonnet`/`opus`/`haiku`/
+      `fable`/`inherit`/full-ID shape).
+- [ ] Resolve the opt-in mechanism (OQ4) and write the chosen pattern up
+      as the house convention, superseding the CLAUDE.md
+      `mcp/server-allowlist` note.
+- [ ] Define how plugin-distributed agents are detected (path heuristic:
+      agent file under a root containing `.claude-plugin/plugin.json`)
+      for `agents/plugin-ignored-fields`.
+- [ ] `docz update`; PR with `dont-release` label.
+
+#### Success Criteria
+
+- DESIGN-0005 status Approved (Donald sign-off on the OQ4 resolution in
+  particular).
+- CLAUDE.md opt-in-rules note updated to point at the new convention.
+
+---
+
+### Phase 4 — Agent rule package
+
+First agent-specific rules. One PR, minor release, fingerprint bump.
+
+#### Tasks
+
+- [ ] Extend `ParseAgent` per DESIGN-0005: `model`, `disallowedTools`,
+      `permissionMode`, `maxTurns`, `skills`, `mcpServers` (presence),
+      `hooks` (presence), `memory`, `background`, `effort`, `isolation`,
+      `color` — with key ranges.
+- [ ] New package `internal/rules/agents/` with blank-import registration
+      in `internal/rules/all/`.
+- [ ] `agents/model-valid` (schema/warning): shared validator; also
+      registered for skill + command `model` fields.
+- [ ] `agents/name-format` (schema/warning): lowercase letters and hyphens
+      only, per the documented constraint.
+- [ ] `agents/tools-known` (schema/warning): shared splitter + classifier
+      over `tools` and `disallowedTools`; diagnostic explains Claude Code
+      silently ignores unknown names.
+- [ ] `agents/plugin-ignored-fields` (content/warning): plugin-rooted
+      agents declaring `mcpServers`/`hooks`/`permissionMode` (documented
+      as ignored for plugin subagents).
+- [ ] `agents/field-enums` (schema/warning): `permissionMode`, `effort`,
+      `color`, `isolation`, `memory` enum membership.
+- [ ] Fixtures: valid agent exercising all documented fields; invalid
+      variants per rule; a plugin-rooted agent fixture.
+- [ ] Ruleset version bump + fingerprint ack; rules.md + README anchors;
+      `claudelint rules <id>` detail entries.
+- [ ] Coverage: new `internal/rules/agents` package must clear the 55%
+      floor (plan tests before code).
+- [ ] Dogfood pass (claude-skills ships plugin agents — prime corpus).
+
+#### Success Criteria
+
+- All five rules fire on their invalid fixtures with correct ranges and
+  pass their valid fixtures.
+- A typo'd `model: sonet` produces a diagnostic naming the valid values.
+- `agents/plugin-ignored-fields` stays silent on project-level
+  (`.claude/agents/`) definitions declaring the same fields.
+- Dogfood run on claude-skills triaged; no untriaged false positives.
+- `just ci` green; minor release ships.
+
+---
+
+### Phase 5 — Policy and remaining validation rules
+
+The governance rule plus the remaining validation batch from INV-0006's
+proposed tables. One PR, minor release, fingerprint bump.
+
+#### Tasks
+
+- [ ] `agents/model-policy` (error, opt-in per the OQ4/DESIGN-0005
+      mechanism): `require = "inherit"` (absent key compliant) or
+      `allowlist = [...]` option shapes.
+- [ ] `hooks/type-known` (schema/error): `type` in the five documented
+      values; absent = `command`.
+- [ ] `hooks/type-fields` (schema/error): per-type required fields
+      (`command` needs `command`; `http` needs `url`; `mcp_tool` needs
+      `server` + `tool`; `prompt`/`agent` need `prompt`).
+- [ ] `mcp/transport-known` (schema/warning): `type` in
+      `stdio`/`http`/`sse`/`ws`; `sse` additionally flagged as
+      documented-deprecated (info).
+- [ ] `mcp/no-secrets-in-headers` (security/error): reuse the
+      `no-secrets-in-env` detector over `headers` values (or fold into
+      that rule — pick during build, note in rules.md either way).
+- [ ] `mcp/timeout-minimum` (schema/warning): `timeout` below 1000 flagged
+      with a seconds-vs-milliseconds hint.
+- [ ] `marketplace/reserved-name` (schema/error): the 16 documented
+      reserved names, exact match; impersonation heuristics deliberately
+      NOT attempted (enforced server-side by claude.ai).
+- [ ] `marketplace/name-format` (style/warning): kebab-case for
+      marketplace name + plugin entry names.
+- [ ] `marketplace/source-path-safety` (security/error): relative sources
+      start with `./`; no `..` segments.
+- [ ] `marketplace/renames-valid` (schema/error): chains terminate at
+      `null` or a listed plugin; no cycles.
+- [ ] `skills/description-length` (content/warning): `description` +
+      `when_to_use` combined at most 1,536 chars.
+- [ ] `skills/fork-agent-pairing` (schema/warning): `agent:` without
+      `context: fork`.
+- [ ] `claude_md/import-exists` (content/warning): `@path` imports resolve
+      relative to the file (respecting `~`); flag chains beyond 4 hops;
+      skip code spans/fences per documented parser behavior.
+- [ ] Fixtures for every rule (valid + invalid pairs).
+- [ ] Ruleset version bump + fingerprint ack; rules.md + README anchors.
+- [ ] Dogfood pass; add "implemented by IMPL-0004" note to INV-0006 and
+      flip this doc to Completed.
+
+#### Success Criteria
+
+- Every new rule has valid/invalid fixture coverage and correct ranges
+  (no file-level `(0,0)` ranges — per-line suppression markers must
+  work).
+- `agents/model-policy` unset behaves exactly per the DESIGN-0005
+  mechanism (no noise on unconfigured repos; enforcement when
+  configured).
+- Full catalog: `claudelint rules --json` lists the expanded ruleset
+  (~49 rules) and `docs/rules-json-schema.md` still validates.
+- Dogfood clean; `just ci` green; minor release ships.
+- IMPL-0004 → Completed; INV-0006 cross-referenced as implemented.
+
+---
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/artifact/parse_mcp.go` | Modify | `mcpServers` key, transport fields, deprecation tagging |
+| `internal/artifact/parse_marketplace.go` | Modify | Object sources, `owner{}`, `renames{}` |
+| `internal/artifact/parse_json.go` | Modify | Hook `type` + per-type fields, exec-form detection |
+| `internal/artifact/parse_md_kinds.go` | Modify | Agent field extension; skill/command new fields |
+| `internal/artifact/parse_markdown.go` | Modify | Shared comma/space tool-list splitter |
+| `internal/artifact/knowndata.go` | Modify | `KnownTools` refresh, `KnownHookEvents` expansion, model-value + tool-pattern classifiers |
+| `internal/artifact/types.go` | Modify | New fields + ranges on `MCPServer`, `MarketplacePlugin`, `HookEntry`, `Agent`, `Skill`, `Command` |
+| `internal/rules/agents/` | Create | Six-rule agent package (Phases 4–5) |
+| `internal/rules/{hooks,mcp,marketplace,skills,claudemd,commands}/` | Modify/Create | Rule fixes + new rules per phase tables |
+| `internal/rules/all/all.go` | Modify | Register the `agents` package |
+| `internal/rules/` version/fingerprint source | Modify | Ruleset version + fingerprint per code phase |
+| `docs/rules/rules.md`, `README.md` | Modify | Catalog + anchors per phase |
+| `docs/design/0005-*.md` | Create | Phase 3 output |
+| `docs/design/0002-*.md` | Modify | §2.2 resolution note |
+| `testdata/**` | Create | Doc-valid + invalid fixtures per phase |
+
+## Testing Plan
+
+- **Unit (per rule/parser)**: table-driven tests; every new parser field
+  asserted with value + range; every rule asserted on valid + invalid
+  fixtures.
+- **Fixture integration**: the doc-valid corpus from Phase 1 runs through
+  `claudelint run` with zero unexpected diagnostics; retained as
+  regression fixtures for later phases.
+- **Fingerprint guardrail**: deliberate acknowledgment in each code
+  phase; CI fails on unacknowledged drift.
+- **Coverage gate**: `just coverage-gate` — 55% floor per `internal/`
+  package, including the new `internal/rules/agents`.
+- **Dogfood**: `just self-check` plus a `donaldgifford/claude-skills`
+  checkout after Phases 2, 4, and 5 (`cd` into the fixture repo — config
+  discovery walks up from CWD).
+- **Docs**: `just lint-md` + `just docs-check` for rules.md/README edits.
+
+## Dependencies
+
+- INV-0006 (merged) — findings and rule tables this implements.
+- DESIGN-0005 (Phase 3 output) — gates Phases 4–5.
+- DESIGN-0001/0002 — existing architecture constraints (rule shape,
+  range-emission conventions, rules never import the engine).
+- Current docs snapshot: `code.claude.com/docs/en/*` fetched 2026-07-09;
+  re-verify the event list and enum values at Phase 1 build time in case
+  the docs have moved again.
+
+## Open Questions
+
+Answer format: **a** is the recommendation; later letters are
+alternatives; reply "other: ..." for anything else.
+
+**OQ1 — `.mcp.json` `servers` key deprecation path.** The parser reads
+`servers` today; the docs standardized on `mcpServers`.
+
+- a) Accept both; `mcpServers` wins when both present; emit an info
+  diagnostic on `servers` ("deprecated key; rename to mcpServers");
+  drop `servers` support at the next major ruleset rev. *(Recommended:
+  zero breakage for existing users including our own DESIGN-0002-era
+  fixtures, loud nudge, clean exit path.)*
+- b) Accept both silently, indefinitely; no diagnostic.
+- c) Hard-switch to `mcpServers` only; `servers` files get a parse-level
+  warning and lint as empty.
+
+**OQ2 — skill `name`/`description` requiredness in
+`schema/frontmatter-required`.** Docs: `name` optional (defaults to the
+directory name), `description` recommended (falls back to the first body
+paragraph).
+
+- a) Keep both required at current severity but reword diagnostics to
+  best-practice phrasing ("skills should declare X — Claude Code falls
+  back to Y"), and document the stricter-than-spec stance in rules.md.
+  *(Recommended: description quality is the entire trigger mechanism;
+  an explicit name costs nothing and helps marketplace review.)*
+- b) Keep `description` required; drop the `name` requirement to match
+  spec.
+- c) Downgrade both to warning severity, behavior otherwise unchanged.
+- d) Match spec exactly: drop `name`, make `description` a warning.
+
+**OQ3 — `plugin/manifest-fields` `version` requirement.** Docs require
+only `name`; a missing `version` falls back to git-SHA versioning.
+
+- a) Keep requiring `version` at error and document it as
+  stricter-by-design (marketplace-quality stance: pinned versions make
+  update semantics explicit). *(Recommended.)*
+- b) Downgrade the missing-`version` half to warning; keep `name` at
+  error.
+- c) Match spec: require `name` only.
+
+**OQ4 — opt-in mechanism for governance rules (`agents/model-policy`).**
+The `mcp/server-allowlist` pattern (default-enabled, nil option → loud
+config error) fits security rules but not governance rules; CLAUDE.md
+says revisit when a second rule needs opt-in — this is that rule.
+
+- a) Config-driven enable: a rule may declare itself opt-in; the engine
+  runs it only when `.claudelint.hcl` has a `rule` block for it. No
+  block → rule fully skipped and shown as "opt-in, disabled" in
+  `claudelint rules`. `mcp/server-allowlist` migrates to the same
+  mechanism (its loud-error-when-unconfigured behavior becomes
+  unreachable by default but is preserved for explicit enables without
+  an allowlist). *(Recommended: one clear convention, no per-rule
+  hacks, discoverable in the catalog.)*
+- b) Documented silent no-op inside the rule when its option is unset —
+  no engine change, cheapest, but invisible in the catalog and
+  inconsistent with `mcp/server-allowlist`.
+- c) Follow the `server-allowlist` precedent exactly: default-enabled,
+  loud config error when unconfigured. (Every unconfigured repo yells
+  about every agent — rejected by INV-0006's analysis but listed for
+  completeness.)
+
+**OQ5 — marketplace `owner` vs `author` alignment.** Docs: root
+`owner{name}` is required; `author` exists only on plugin entries.
+
+- a) Repurpose `marketplace/author-required` into
+  `marketplace/owner-required` checking root `owner.name` at warning
+  severity (rule-ID rename — the fingerprint is bumping anyway); legacy
+  `author` satisfies the check with an info-level "rename to owner"
+  hint. *(Recommended.)*
+- b) Keep `author-required` as-is (info) and add a separate
+  `marketplace/owner-required` (warning) — two rules, no rename.
+- c) Leave everything as today; note the divergence in rules.md only.
+
+**OQ6 — release cadence for the three code PRs.**
+
+- a) Each code PR ships as its own minor release via the label-driven
+  flow; the ruleset version bumps minor each time. *(Recommended: keeps
+  fingerprints, changelogs, and dogfood feedback loops small.)*
+- b) Land Phases 1–2 and 4 on a long-lived branch and ship one combined
+  minor together with Phase 5.
+
+**OQ7 — where `allowed-tools` validation lives after the skills/commands
+merge.**
+
+- a) Extend `commands/allowed-tools-known` `AppliesTo` to
+  `command, skill` and keep the existing rule ID — no config breakage
+  for current users; rules.md notes it covers both kinds.
+  *(Recommended.)*
+- b) New sibling rule `skills/allowed-tools-known` sharing the
+  implementation — cleaner naming, one more catalog entry.
+- c) Rename to a kind-neutral `schema/allowed-tools-known` — cleanest
+  naming, but breaks existing rule-ID references in user configs.
+
+**OQ8 — `hooks/timeout-present` disposition given the documented 600 s
+default timeout.**
+
+- a) Keep at warning with a rewritten message ("no explicit timeout;
+  Claude Code defaults to 600 s — declare one to fail faster in CI").
+  *(Recommended: explicit timeouts remain a real best practice for
+  plugin/marketplace review, claudelint's core audience.)*
+- b) Downgrade to info.
+- c) Retire the rule.
+
+## References
+
+- [INV-0006](../investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md)
+  — audit tables this implements, including per-rule verdicts and doc
+  URLs
+- [DESIGN-0001](../design/0001-claudelint-linter-architecture-and-rule-engine.md)
+  — rule interface, range conventions, registration
+- [DESIGN-0002](../design/0002-phase-2-marketplaces-mcp-rules-and-github-action.md)
+  — §2.2 `.mcp.json` key decision being revised
+- DESIGN-0005 — Phase 3 output (agent package + opt-in mechanism)
+- [INV-0005](../investigation/0005-phase-2-dogfood-findings-marketplaces-mcp-and-spec-divergence.md)
+  — dogfood-pass precedent
+- Claude Code docs: sub-agents, skills, slash-commands, hooks,
+  hooks-guide, mcp, plugins-reference, plugin-marketplaces, memory
+  (`code.claude.com/docs/en/*`, fetched 2026-07-09)

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -42,4 +42,5 @@ docz create impl "Your Implementation Title"
 | IMPL-0001 | Phase 1: core linter for CLAUDE.md, skills, plugins, and hooks | Draft | 2026-04-18 | Donald Gifford | [0001-phase-1-core-linter-for-claudemd-skills-plugins-and-hooks.md](0001-phase-1-core-linter-for-claudemd-skills-plugins-and-hooks.md) |
 | IMPL-0002 | Phase 2 — marketplaces, MCP rules, SARIF, and GitHub Action | Draft | 2026-04-23 | Donald Gifford | [0002-phase-2-marketplaces-mcp-rules-sarif-and-github-action.md](0002-phase-2-marketplaces-mcp-rules-sarif-and-github-action.md) |
 | IMPL-0003 | Phase 3 — Dual-output docs site with Starlight | Completed | 2026-05-31 | Donald Gifford | [0003-phase-3-dual-output-docs-site-with-starlight.md](0003-phase-3-dual-output-docs-site-with-starlight.md) |
+| IMPL-0004 | Phase 4 - Ruleset alignment and agent rules | Draft | 2026-07-09 | Donald Gifford | [0004-phase-4-ruleset-alignment-and-agent-rules.md](0004-phase-4-ruleset-alignment-and-agent-rules.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md
+++ b/docs/investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md
@@ -196,7 +196,8 @@ sees the data. These block the fixes and the new rules:
 
 Phase column maps to the [Recommendation](#recommendation): **PR 1** =
 correctness fixes, **PR 2** = agent package, **PR 3** = policy + design
-pass, **Backlog** = later.
+pass. Every proposed rule lands in one of the three PRs — nothing is
+deferred to a later backlog.
 
 #### Agents (no rules exist today)
 
@@ -207,14 +208,14 @@ pass, **Backlog** = later.
 | `agents/tools-known` | Entries in `tools`/`disallowedTools` are known tools, `mcp__*` patterns, or `Agent(...)` forms — Claude Code **silently ignores** unknown names. | warning | PR 2 |
 | `agents/plugin-ignored-fields` | Plugin-distributed agents declaring `mcpServers`, `hooks`, or `permissionMode` — documented as ignored for plugin subagents (dead config). | warning | PR 2 |
 | `agents/model-policy` | Opt-in enforcement: `require = "inherit"` or `allowlist = [...]`. | error (opt-in) | PR 3 |
-| `agents/field-enums` | `permissionMode` (7 values), `effort` (5), `color` (8), `isolation` (`worktree`), `memory` (`user`/`project`/`local`) are valid enum members. | warning | Backlog |
+| `agents/field-enums` | `permissionMode` (7 values), `effort` (5), `color` (8), `isolation` (`worktree`), `memory` (`user`/`project`/`local`) are valid enum members. | warning | PR 2 |
 
 #### Skills and commands
 
 | Proposed rule | Checks | Severity | Phase |
 |---|---|---|---|
 | `skills/description-length` | `description` + `when_to_use` combined ≤ 1,536 chars (documented truncation silently drops trigger phrases). | warning | PR 3 |
-| `skills/fork-agent-pairing` | `agent:` set without `context: fork` does nothing. | warning | Backlog |
+| `skills/fork-agent-pairing` | `agent:` set without `context: fork` does nothing. | warning | PR 3 |
 | (extend) `commands/allowed-tools-known` → skills | Same rule runs on skill `allowed-tools`/`disallowed-tools` after the merged-model parser update. | error | PR 1 |
 
 #### Hooks
@@ -231,7 +232,7 @@ pass, **Backlog** = later.
 | `marketplace/reserved-name` | Name not in the 16 documented reserved names (and obvious impersonations); claude.ai sync blocks these. | error | PR 3 |
 | `marketplace/name-format` | Marketplace + plugin-entry names kebab-case (claude.ai sync rejects violations). | warning | PR 3 |
 | `marketplace/source-path-safety` | Relative sources start with `./`; no `..` traversal (validator-rejected). | error | PR 3 |
-| `marketplace/renames-valid` | `renames{}` chains terminate (at `null` or a listed plugin) and contain no cycles. | error | Backlog |
+| `marketplace/renames-valid` | `renames{}` chains terminate (at `null` or a listed plugin) and contain no cycles. | error | PR 3 |
 
 #### MCP servers
 
@@ -240,13 +241,13 @@ pass, **Backlog** = later.
 | `mcp/url-required` | `http`/`sse`/`ws` transports declare `url` (counterpart to stdio-scoped `command-required`). | error | PR 1 |
 | `mcp/transport-known` | `type` ∈ `stdio`/`http`/`sse`/`ws`; flag `sse` as documented-deprecated (info). | warning | PR 3 |
 | `mcp/no-secrets-in-headers` | Secrets scan over `headers` values (or fold into `no-secrets-in-env`). | error | PR 3 |
-| `mcp/timeout-minimum` | `timeout` is in **milliseconds** with documented minimum 1000 — catches seconds-vs-ms confusion. | warning | Backlog |
+| `mcp/timeout-minimum` | `timeout` is in **milliseconds** with documented minimum 1000 — catches seconds-vs-ms confusion. | warning | PR 3 |
 
 #### CLAUDE.md
 
 | Proposed rule | Checks | Severity | Phase |
 |---|---|---|---|
-| `claude_md/import-exists` | `@path` imports resolve on disk; flag chains beyond the documented 4-hop depth. | warning | Backlog |
+| `claude_md/import-exists` | `@path` imports resolve on disk; flag chains beyond the documented 4-hop depth. | warning | PR 3 |
 
 #### Deliberately not chasing yet
 
@@ -358,11 +359,16 @@ Phase the work as three PRs, in this order:
    severities. Update DESIGN-0002 §2.2 and the affected rules docs.
 2. **PR 2 — agent rule package:** extend `ParseAgent` to the documented
    field set, then `agents/model-valid`, `agents/name-format`,
-   `agents/tools-known`, `agents/plugin-ignored-fields`. Fingerprint bump;
-   per-package coverage gate applies.
+   `agents/tools-known`, `agents/plugin-ignored-fields`,
+   `agents/field-enums`. Fingerprint bump; per-package coverage gate
+   applies.
 3. **PR 3 — policy + design pass:** `agents/model-policy` plus the opt-in
-   mechanism decision, hook type rules, MCP transport rules, marketplace
-   name/safety rules. Backlog rows feed later phases.
+   mechanism decision, hook type rules (`type-known`, `type-fields`), MCP
+   transport rules (`transport-known`, `no-secrets-in-headers`,
+   `timeout-minimum`), marketplace name/safety rules (`reserved-name`,
+   `name-format`, `source-path-safety`, `renames-valid`),
+   `skills/description-length`, `skills/fork-agent-pairing`, and
+   `claude_md/import-exists`.
 
 Write DESIGN-0005 covering PRs 2–3 before implementing; PR 1 is executable
 directly against DESIGN-0001/0002 with doc updates to the affected sections.

--- a/docs/investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md
+++ b/docs/investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md
@@ -1,0 +1,364 @@
+---
+id: INV-0006
+title: "Rule coverage audit against current Claude Code docs"
+status: Concluded
+author: Donald Gifford
+created: 2026-07-09
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV 0006: Rule coverage audit against current Claude Code docs
+
+**Status:** Concluded
+**Author:** Donald Gifford
+**Date:** 2026-07-09
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Environment](#environment)
+- [Findings](#findings)
+  - [Observation 1 — divergences that produce wrong results today](#observation-1--divergences-that-produce-wrong-results-today)
+  - [Observation 2 — rules stricter than the current spec](#observation-2--rules-stricter-than-the-current-spec)
+  - [Observation 3 — agents are a coverage hole](#observation-3--agents-are-a-coverage-hole)
+  - [Observation 4 — the agent model question](#observation-4--the-agent-model-question)
+  - [Observation 5 — new surface with no coverage yet](#observation-5--new-surface-with-no-coverage-yet)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+Is the shipping ruleset (v1.2.0, fingerprint `e7f26796`, 30 rules) still
+aligned with the current Anthropic Claude Code documentation for agents,
+skills, commands, plugins, marketplaces, hooks, MCP servers, and CLAUDE.md —
+and specifically, should claudelint validate the agent `model` frontmatter
+field and/or offer an enforcement rule for pinning a model vs. requiring
+`inherit`?
+
+## Hypothesis
+
+The ruleset lags the docs. Claude Code has shipped continuously since the
+Phase 2 rules were written (docs carry version markers through v2.1.205);
+expected gaps: new hook events, new frontmatter fields, and zero agent-kind
+rules. Suspected but unconfirmed going in: the `.mcp.json` top-level key
+divergence flagged in DESIGN-0002 §2.2 ("if Claude Code standardizes on
+`mcpServers`, revisit").
+
+## Context
+
+Triggered by the post-v0.2.0 question "are we missing anything from the most
+current Anthropic documentation?", plus a concrete feature question about
+enforcing agent `model` frontmatter. The last systematic doc-vs-ruleset pass
+was INV-0005 (the `claude-skills` dogfood) during Phase 2.
+
+**Triggered by:** DESIGN-0002 §2.2 open watch-item; user request 2026-07-09
+
+## Approach
+
+1. Dump the shipping catalog: `claudelint rules --json` (30 rules,
+   v1.2.0/`e7f26796`).
+2. Inventory what the parsers and rules actually check, with file:line refs —
+   hardcoded tool list, hook-event list, required-frontmatter keys, MCP/plugin/
+   marketplace field extraction, thresholds.
+3. Fetch the current official docs for each artifact kind (sub-agents, skills,
+   slash-commands, plugins-reference, plugin-marketplaces, hooks, hooks-guide,
+   mcp, memory) and extract the full field/constraint tables.
+4. Diff 2 against 3; classify each gap as (a) wrong-today, (b) stricter than
+   spec, or (c) new surface with no coverage.
+
+## Environment
+
+| Component | Version / Value |
+|-----------|----------------|
+| claudelint ruleset | v1.2.0, fingerprint `e7f26796`, 30 rules |
+| claudelint release | v0.2.3 (latest tag) |
+| Docs source | `code.claude.com/docs/en/*`, fetched 2026-07-09 |
+| Claude Code doc version markers | through v2.1.205 |
+
+## Findings
+
+### Observation 1 — divergences that produce wrong results today
+
+These are cases where linting a config that is **valid per current docs**
+produces a false positive, or where clearly invalid input passes silently.
+
+**1a. Hook event list is 9 of ~29 events — false errors on valid configs.**
+`KnownHookEvents` (`internal/artifact/knowndata.go:42-52`) has `PreToolUse`,
+`PostToolUse`, `UserPromptSubmit`, `Notification`, `Stop`, `SubagentStop`,
+`PreCompact`, `SessionStart`, `SessionEnd`. The docs now also define `Setup`,
+`SessionEnd` reasons aside, `UserPromptExpansion`, `StopFailure`,
+`PostToolUseFailure`, `PostToolBatch`, `PermissionRequest`,
+`PermissionDenied`, `MessageDisplay`, `ConfigChange`, `CwdChanged`,
+`FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PostCompact`,
+`SubagentStart`, `TeammateIdle`, `TaskCreated`, `TaskCompleted`,
+`InstructionsLoaded`, `Elicitation`, `ElicitationResult`. Because
+`hooks/event-name-known` is a default-**error** rule, a settings file using
+`SubagentStart` (documented) fails the lint today.
+
+**1b. Hook entries now have five types; we only understand `command`.**
+Valid `type` values are `command`, `http`, `mcp_tool`, `prompt`, `agent`,
+each with different required fields (`command` / `url` / `server`+`tool` /
+`prompt`). The parser (`internal/artifact/parse_json.go`) ignores `type`
+entirely and only extracts `command` + `timeout`. Consequences: an `http`
+hook is parsed as a command-less entry (no rule catches a missing `url`); a
+typo'd `type` passes silently; `hooks/no-unsafe-shell` never inspects
+`prompt`/`agent` hooks. Also: command hooks have a **default 600 s timeout**
+per the docs, so `hooks/timeout-present`'s premise ("a runaway hook can hang
+the session") is now a style nudge, not a correctness issue — its message
+and doc entry should say so.
+
+**1c. `.mcp.json` top-level key: docs say `mcpServers`, we parse `servers`.**
+The watch-item in DESIGN-0002 §2.2 has resolved against us: every current
+doc example uses `mcpServers{}` at the root of project `.mcp.json`
+(`code.claude.com/docs/en/mcp`). `ParseMCPFile`
+(`internal/artifact/parse_mcp.go:37`) reads `servers` — a doc-conforming
+`.mcp.json` lints as "no servers" (all MCP rules silently skip). This is the
+highest-value single fix in the audit.
+
+**1d. MCP transports: we only model stdio.**
+Server entries support `type` (`stdio` default, `http`, `sse` — deprecated,
+`ws`), `url`, `headers`, `headersHelper`, `oauth{}`, `timeout` (ms, min
+1000), `alwaysLoad`. We parse none of these. `mcp/command-required` would
+false-positive on a valid `http` server (which has `url`, no `command`) the
+moment the 1c fix lands, so 1c and 1d must ship together:
+`command-required` applies to stdio only; a matching `url`-required check
+covers the remote transports.
+
+**1e. Marketplace plugin sources can be objects; we only parse strings.**
+Docs define object sources — `{"source": "github", "repo": ...}`,
+`{"source": "url", ...}`, `{"source": "git-subdir", ...}`,
+`{"source": "npm", ...}` — alongside relative-path strings. The parser
+(`internal/artifact/parse_marketplace.go`) reads `source` as a string, so an
+object source parses as empty and `marketplace/plugin-source-valid` (error)
+fires on a doc-valid marketplace. Note this is the same class of bug as the
+nested-`metadata.version` false positive found in INV-0005 — the docs have
+since **confirmed** `metadata.version`/`owner{}` as documented
+backward-compat shapes, so our existing fallback parsing is correct and can
+be annotated as spec-compliant rather than defensive.
+
+**1f. `allowed-tools` string forms and permission-rule syntax.**
+Docs (skills + slash-commands): `allowed-tools` accepts a YAML list **or a
+space/comma-separated string**, and entries may be permission rules like
+`Bash(git add:*)`, `mcp__github`, or `Agent(worker)`. Our `asStringList`
+(`internal/artifact/parse_markdown.go:248`) never splits strings, so
+`allowed-tools: Read, Grep` is one unknown tool named `"Read, Grep"` →
+`commands/allowed-tools-known` (error) false-positives. The rule also flags
+any parenthesized or `mcp__*` entry. Separately, `KnownTools`
+(`internal/artifact/knowndata.go:12-29`, 16 names) predates the `Task` →
+`Agent` rename (v2.1.63; both valid) and lacks `Agent`, `Skill`, and the
+MCP wildcard forms.
+
+**1g. Commands and skills have merged.**
+`.claude/commands/*.md` still works but is documented as a legacy alias for
+skills; both share one frontmatter model (17 fields — `when_to_use`,
+`arguments`, `argument-hint`, `disable-model-invocation`, `user-invocable`,
+`allowed-tools`, `disallowed-tools`, `model`, `effort`, `context`, `agent`,
+`hooks`, `paths`, `shell`, ...). Our `KindCommand`/`KindSkill` split remains
+useful for discovery, but rules that only run on one kind (e.g.
+`commands/allowed-tools-known` not running on skills) now leave documented
+fields unlinted on the other kind.
+
+### Observation 2 — rules stricter than the current spec
+
+Not bugs — places where claudelint demands more than Claude Code requires.
+Each needs a deliberate keep/relax decision, and the rules doc should state
+"stricter than spec, by design" for the keepers.
+
+| Rule | We require | Docs say |
+|---|---|---|
+| `plugin/manifest-fields` | `name` + `version` | only `name` required; missing `version` falls back to git commit SHA |
+| `marketplace/version-semver` | `version` present + semver | root `version` is optional |
+| `schema/frontmatter-required` (skill) | `name` + `description` | `name` optional (defaults to dir name); `description` recommended (falls back to first body paragraph) |
+| `schema/frontmatter-required` (agent) | `name` + `description` | both genuinely required — matches spec |
+
+Recommendation per row is in the Recommendation section. The skill-name
+check has a subtlety worth keeping: `name` only controls invocation for
+plugin-root SKILL.md, so requiring it is cheap hygiene, but the diagnostic
+message should stop implying Claude Code requires it.
+
+### Observation 3 — agents are a coverage hole
+
+`KindAgent` exists, but the parser extracts only `name`, `description`,
+`tools` (`internal/artifact/parse_md_kinds.go:56-70`), and **zero
+agent-specific rules are registered** — agents get `schema/frontmatter-required`
+plus the every-kind rules and nothing else.
+
+The current sub-agents doc defines 16 frontmatter fields: `name`,
+`description`, `model`, `tools`, `disallowedTools`, `permissionMode`,
+`maxTurns`, `skills`, `mcpServers`, `hooks`, `memory`, `background`,
+`effort`, `isolation`, `color`, `initialPrompt`. Three documented behaviors
+make agents unusually lint-worthy:
+
+1. **Unknown tool names in `tools` are silently ignored** by Claude Code —
+   a typo'd tool never errors at runtime; the agent just quietly lacks it.
+   This is exactly the failure mode a linter exists for.
+2. **`name` has a real constraint** (lowercase letters and hyphens only)
+   that Claude Code does not loudly enforce; duplicates resolve by
+   undocumented filesystem order.
+3. **Plugin subagents silently ignore `mcpServers`, `hooks`, and
+   `permissionMode`** — declaring them in a plugin's `agents/*.md` does
+   nothing. A rule can catch dead config that authors believe is active.
+
+### Observation 4 — the agent model question
+
+What the docs actually specify (`code.claude.com/docs/en/sub-agents.md`):
+
+- Valid `model` values: aliases (`sonnet`, `opus`, `haiku`, `fable`), full
+  model IDs (e.g. `claude-opus-4-8`), or `inherit`.
+- **Omitted means `inherit`** — the default changed to inherit-from-parent;
+  an explicit `inherit` and an absent key are equivalent (since v2.1.196
+  even via the `CLAUDE_CODE_SUBAGENT_MODEL` env override path).
+- Values excluded by an org's `availableModels` allowlist are skipped at
+  resolution time and fall back to the inherited model — misconfiguration
+  degrades silently rather than failing.
+
+That maps onto two rules with different jobs:
+
+**`agents/model-valid` (validation — default-enabled, warning).** If `model`
+is present, check it is an alias, `inherit`, or matches a full-ID shape
+(`^claude-[a-z0-9-]+$`). Catches `model: sonet` typos, which today silently
+resolve to the inherited model. No options needed. Also applies verbatim to
+the skill/command `model` field (same value set per the skills doc), so the
+check should live in shared validation with per-kind registration.
+
+**`agents/model-policy` (enforcement — opt-in).** Governance rule for repos
+and marketplaces that want a stance, with an option taking one of two
+shapes:
+
+    rule "agents/model-policy" {
+      options = { require = "inherit" }   # every agent must inherit
+    }
+
+    rule "agents/model-policy" {
+      options = { allowlist = ["inherit", "haiku", "sonnet"] }
+    }
+
+`require = "inherit"` treats an absent key as compliant (absence ==
+inherit per the docs) and flags any pinned model — the right default for
+cost/consistency governance and for marketplace review. `allowlist` permits
+deliberate pinning (e.g. cheap models for utility agents) while blocking
+everything else.
+
+**Pattern tension worth deciding explicitly:** the house pattern
+(`mcp/server-allowlist`, per CLAUDE.md) is "default-enabled, nil option →
+loud config error". That is right for a security rule; for a governance
+rule it would make every un-configured repo yell about every agent.
+CLAUDE.md already anticipated this: "Adding `Rule.Enabled()` for one rule
+is over-engineering; **revisit only if multiple rules need the pattern**."
+`agents/model-policy` is that second rule. The Phase 4 design should either
+add an opt-in mechanism (config-driven enable, or `Rule.Enabled()`) or
+accept a documented silent no-op when the option is unset — silent no-op is
+acceptable here precisely because absence-of-policy is a valid state,
+unlike absence-of-allowlist on a security rule.
+
+### Observation 5 — new surface with no coverage yet
+
+Lower urgency; candidates for the backlog rather than the next release.
+
+- **Agents (beyond Observation 3/4):** `agents/name-format` (lowercase +
+  hyphens), `agents/tools-known` (the silent-ignore catch),
+  `agents/plugin-ignored-fields` (plugin agents declaring
+  `mcpServers`/`hooks`/`permissionMode`), enum checks for
+  `permissionMode`/`effort`/`color`/`isolation`/`memory`.
+- **Skills:** `skills/description-length` — `description` + `when_to_use`
+  are truncated at 1,536 combined chars, so overlong descriptions lose
+  their trigger phrases silently; body-size guidance is now "under 500
+  lines" (our `max_words = 1000` is compatible; consider a lines variant).
+  `context: fork` / `agent` pairing check (an `agent` field without
+  `context: fork` does nothing).
+- **Marketplaces:** reserved-name check (16 reserved/impersonation-blocked
+  marketplace names documented), `renames{}` cycle validation, source path
+  traversal (`..` rejected), relative sources must start with `./`,
+  kebab-case name format (claude.ai sync rejects violations).
+- **Hooks:** per-type required-field validation once 1b lands;
+  `disableAllHooks` awareness; `timeout` unit sanity (seconds, not ms).
+- **MCP:** `sse` transport deprecation warning; secrets scanning in
+  `headers` (today only `env` is scanned); `timeout` minimum (1000 ms).
+- **CLAUDE.md:** `@path` import resolution (imports exist on disk; ≤ 4-hop
+  depth documented); the docs' size guidance is "under 200 lines" vs our
+  default `max_lines = 500` — defensible, but worth a comment in the rule.
+- **Not worth chasing yet:** path-scoped rule files (`.claude/rules/*.md`
+  with `paths:` frontmatter) as a ninth artifact kind, LSP servers, output
+  styles, monitors (`experimental.*`), `userConfig` schema validation.
+  Revisit when they stabilize (monitors/themes are explicitly marked
+  experimental).
+
+## Conclusion
+
+**Answer: Yes — the ruleset has drifted, in both directions.**
+
+Seven findings produce wrong results today (Observation 1), the worst being
+the `.mcp.json` `servers` → `mcpServers` divergence (valid files lint as
+empty) and the 9-of-29 hook-event list (valid configs fail with errors).
+Four rules are deliberately-or-accidentally stricter than the documented
+spec (Observation 2). Agents — the artifact kind Donald asked about — have
+the largest gap: a 16-field documented spec, three silent-failure behaviors
+worth linting, and zero agent rules shipped (Observation 3).
+
+On the model question (Observation 4): yes, and it should be two rules —
+always-on **validation** of the value set (`sonnet`/`opus`/`haiku`/`fable`/
+full-ID/`inherit`), and **opt-in enforcement** (`require = "inherit"` or an
+allowlist) following — and finally forcing the anticipated revisit of — the
+opt-in-rule pattern.
+
+## Recommendation
+
+Phase the work as three PRs, in this order:
+
+1. **Correctness fixes (patch/minor, no new rules):** expand
+   `KnownHookEvents` to the full documented set; accept `mcpServers` as the
+   primary `.mcp.json` key (keep `servers` with a deprecation info
+   diagnostic for one release); parse marketplace object sources so
+   `plugin-source-valid` stops false-positive-ing (and start validating the
+   documented per-type required fields); split string-form `allowed-tools`
+   on commas/whitespace and accept permission-rule + `mcp__*` syntax;
+   refresh `KnownTools` (add `Agent`, `Skill`; keep `Task` as alias).
+   Update Observation 2 rows: keep `plugin/manifest-fields` and skill
+   frontmatter checks as documented stricter-than-spec defaults, but split
+   `marketplace/version-semver` (missing → info, non-semver → error).
+2. **Agent rule package (minor):** `agents/model-valid`,
+   `agents/name-format`, `agents/tools-known`,
+   `agents/plugin-ignored-fields` — requires extending the agent parser to
+   the documented field set (at minimum `model`, `disallowedTools`,
+   `permissionMode`, `mcpServers`, `hooks`, plus ranges). This bumps the
+   ruleset fingerprint and needs the coverage-gate check per package.
+3. **Policy + design pass:** `agents/model-policy` plus the opt-in
+   mechanism decision (second consumer of the pattern → design the
+   general solution), hook per-type validation, MCP transport rules.
+   Items in Observation 5 feed the backlog.
+
+Write a DESIGN doc (Phase 4 / DESIGN-0005) covering 2–3 before
+implementing; item 1 is executable directly against DESIGN-0001/0002 with
+doc updates to the affected sections (DESIGN-0002 §2.2 in particular).
+
+## References
+
+- Rule catalog: `claudelint rules --json` @ v1.2.0 / `e7f26796`
+- Source inventory: `internal/artifact/knowndata.go`,
+  `internal/artifact/parse_json.go`, `internal/artifact/parse_mcp.go`,
+  `internal/artifact/parse_marketplace.go`,
+  `internal/artifact/parse_md_kinds.go`, `internal/rules/**`
+- [Sub-agents](https://code.claude.com/docs/en/sub-agents) — frontmatter
+  spec incl. `model` resolution and `inherit` default
+- [Skills](https://code.claude.com/docs/en/skills) and
+  [Slash commands](https://code.claude.com/docs/en/slash-commands) —
+  merged frontmatter model, `allowed-tools` forms, 1,536-char cap
+- [Hooks reference](https://code.claude.com/docs/en/hooks) and
+  [Hooks guide](https://code.claude.com/docs/en/hooks-guide) — event list,
+  five hook types, timeout defaults
+- [MCP](https://code.claude.com/docs/en/mcp) — `mcpServers` key,
+  transports, oauth/headers fields
+- [Plugins reference](https://code.claude.com/docs/en/plugins-reference)
+  and [Plugin marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
+  — manifest schemas, source types, reserved names, `renames`
+- [Memory](https://code.claude.com/docs/en/memory) — CLAUDE.md locations,
+  `@path` imports, size guidance
+- [DESIGN-0002](../design/0002-phase-2-marketplaces-mcp-rules-and-github-action.md)
+  §2.2 — the `servers` vs `mcpServers` watch-item this INV resolves
+- [INV-0005](./0005-phase-2-dogfood-findings-marketplaces-mcp-and-spec-divergence.md)
+  — prior dogfood pass; nested `metadata.version` finding now confirmed
+  as documented backward-compat

--- a/docs/investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md
+++ b/docs/investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md
@@ -20,11 +20,27 @@ created: 2026-07-09
 - [Approach](#approach)
 - [Environment](#environment)
 - [Findings](#findings)
-  - [Observation 1 — divergences that produce wrong results today](#observation-1--divergences-that-produce-wrong-results-today)
-  - [Observation 2 — rules stricter than the current spec](#observation-2--rules-stricter-than-the-current-spec)
-  - [Observation 3 — agents are a coverage hole](#observation-3--agents-are-a-coverage-hole)
-  - [Observation 4 — the agent model question](#observation-4--the-agent-model-question)
-  - [Observation 5 — new surface with no coverage yet](#observation-5--new-surface-with-no-coverage-yet)
+  - [Existing rules — audit by kind](#existing-rules--audit-by-kind)
+    - [Cross-cutting rules](#cross-cutting-rules)
+    - [CLAUDE.md rules](#claudemd-rules)
+    - [Skill rules](#skill-rules)
+    - [Command rules](#command-rules)
+    - [Hook rules](#hook-rules)
+    - [Plugin rules](#plugin-rules)
+    - [Marketplace rules](#marketplace-rules)
+    - [MCP rules](#mcp-rules)
+  - [Parser and shared-helper gaps](#parser-and-shared-helper-gaps)
+  - [Proposed new rules by kind](#proposed-new-rules-by-kind)
+    - [Agents (no rules exist today)](#agents-no-rules-exist-today)
+    - [Skills and commands](#skills-and-commands)
+    - [Hooks](#hooks)
+    - [Marketplaces](#marketplaces)
+    - [MCP servers](#mcp-servers)
+    - [CLAUDE.md](#claudemd)
+    - [Deliberately not chasing yet](#deliberately-not-chasing-yet)
+  - [Detail — divergences that produce wrong results today](#detail--divergences-that-produce-wrong-results-today)
+  - [Detail — rules stricter than the current spec](#detail--rules-stricter-than-the-current-spec)
+  - [Detail — the agent model question](#detail--the-agent-model-question)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
 - [References](#references)
@@ -67,8 +83,8 @@ was INV-0005 (the `claude-skills` dogfood) during Phase 2.
 3. Fetch the current official docs for each artifact kind (sub-agents, skills,
    slash-commands, plugins-reference, plugin-marketplaces, hooks, hooks-guide,
    mcp, memory) and extract the full field/constraint tables.
-4. Diff 2 against 3; classify each gap as (a) wrong-today, (b) stricter than
-   spec, or (c) new surface with no coverage.
+4. Diff 2 against 3; classify each existing rule and enumerate missing rules,
+   per artifact kind.
 
 ## Environment
 
@@ -81,259 +97,275 @@ was INV-0005 (the `claude-skills` dogfood) during Phase 2.
 
 ## Findings
 
-### Observation 1 — divergences that produce wrong results today
+### Existing rules — audit by kind
 
-These are cases where linting a config that is **valid per current docs**
-produces a false positive, or where clearly invalid input passes silently.
+Verdict legend:
 
-**1a. Hook event list is 9 of ~29 events — false errors on valid configs.**
-`KnownHookEvents` (`internal/artifact/knowndata.go:42-52`) has `PreToolUse`,
-`PostToolUse`, `UserPromptSubmit`, `Notification`, `Stop`, `SubagentStop`,
-`PreCompact`, `SessionStart`, `SessionEnd`. The docs now also define `Setup`,
-`SessionEnd` reasons aside, `UserPromptExpansion`, `StopFailure`,
-`PostToolUseFailure`, `PostToolBatch`, `PermissionRequest`,
-`PermissionDenied`, `MessageDisplay`, `ConfigChange`, `CwdChanged`,
-`FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PostCompact`,
-`SubagentStart`, `TeammateIdle`, `TaskCreated`, `TaskCompleted`,
-`InstructionsLoaded`, `Elicitation`, `ElicitationResult`. Because
-`hooks/event-name-known` is a default-**error** rule, a settings file using
-`SubagentStart` (documented) fails the lint today.
+- **Fix** — produces wrong results against doc-valid input today
+- **Update** — behavior/premise/message needs expansion or adjustment
+- **Keep** — aligned with current docs, no change
+- **Keep (stricter)** — deliberately stricter than spec; document the stance
+- **Decide** — stricter than spec in a way that needs a keep/relax call
 
-**1b. Hook entries now have five types; we only understand `command`.**
-Valid `type` values are `command`, `http`, `mcp_tool`, `prompt`, `agent`,
-each with different required fields (`command` / `url` / `server`+`tool` /
-`prompt`). The parser (`internal/artifact/parse_json.go`) ignores `type`
-entirely and only extracts `command` + `timeout`. Consequences: an `http`
-hook is parsed as a command-less entry (no rule catches a missing `url`); a
-typo'd `type` passes silently; `hooks/no-unsafe-shell` never inspects
-`prompt`/`agent` hooks. Also: command hooks have a **default 600 s timeout**
-per the docs, so `hooks/timeout-present`'s premise ("a runaway hook can hang
-the session") is now a style nudge, not a correctness issue — its message
-and doc entry should say so.
+#### Cross-cutting rules
 
-**1c. `.mcp.json` top-level key: docs say `mcpServers`, we parse `servers`.**
-The watch-item in DESIGN-0002 §2.2 has resolved against us: every current
-doc example uses `mcpServers{}` at the root of project `.mcp.json`
-(`code.claude.com/docs/en/mcp`). `ParseMCPFile`
-(`internal/artifact/parse_mcp.go:37`) reads `servers` — a doc-conforming
-`.mcp.json` lints as "no servers" (all MCP rules silently skip). This is the
-highest-value single fix in the audit.
-
-**1d. MCP transports: we only model stdio.**
-Server entries support `type` (`stdio` default, `http`, `sse` — deprecated,
-`ws`), `url`, `headers`, `headersHelper`, `oauth{}`, `timeout` (ms, min
-1000), `alwaysLoad`. We parse none of these. `mcp/command-required` would
-false-positive on a valid `http` server (which has `url`, no `command`) the
-moment the 1c fix lands, so 1c and 1d must ship together:
-`command-required` applies to stdio only; a matching `url`-required check
-covers the remote transports.
-
-**1e. Marketplace plugin sources can be objects; we only parse strings.**
-Docs define object sources — `{"source": "github", "repo": ...}`,
-`{"source": "url", ...}`, `{"source": "git-subdir", ...}`,
-`{"source": "npm", ...}` — alongside relative-path strings. The parser
-(`internal/artifact/parse_marketplace.go`) reads `source` as a string, so an
-object source parses as empty and `marketplace/plugin-source-valid` (error)
-fires on a doc-valid marketplace. Note this is the same class of bug as the
-nested-`metadata.version` false positive found in INV-0005 — the docs have
-since **confirmed** `metadata.version`/`owner{}` as documented
-backward-compat shapes, so our existing fallback parsing is correct and can
-be annotated as spec-compliant rather than defensive.
-
-**1f. `allowed-tools` string forms and permission-rule syntax.**
-Docs (skills + slash-commands): `allowed-tools` accepts a YAML list **or a
-space/comma-separated string**, and entries may be permission rules like
-`Bash(git add:*)`, `mcp__github`, or `Agent(worker)`. Our `asStringList`
-(`internal/artifact/parse_markdown.go:248`) never splits strings, so
-`allowed-tools: Read, Grep` is one unknown tool named `"Read, Grep"` →
-`commands/allowed-tools-known` (error) false-positives. The rule also flags
-any parenthesized or `mcp__*` entry. Separately, `KnownTools`
-(`internal/artifact/knowndata.go:12-29`, 16 names) predates the `Task` →
-`Agent` rename (v2.1.63; both valid) and lacks `Agent`, `Skill`, and the
-MCP wildcard forms.
-
-**1g. Commands and skills have merged.**
-`.claude/commands/*.md` still works but is documented as a legacy alias for
-skills; both share one frontmatter model (17 fields — `when_to_use`,
-`arguments`, `argument-hint`, `disable-model-invocation`, `user-invocable`,
-`allowed-tools`, `disallowed-tools`, `model`, `effort`, `context`, `agent`,
-`hooks`, `paths`, `shell`, ...). Our `KindCommand`/`KindSkill` split remains
-useful for discovery, but rules that only run on one kind (e.g.
-`commands/allowed-tools-known` not running on skills) now leave documented
-fields unlinted on the other kind.
-
-### Observation 2 — rules stricter than the current spec
-
-Not bugs — places where claudelint demands more than Claude Code requires.
-Each needs a deliberate keep/relax decision, and the rules doc should state
-"stricter than spec, by design" for the keepers.
-
-| Rule | We require | Docs say |
+| Rule | Verdict | Action needed |
 |---|---|---|
-| `plugin/manifest-fields` | `name` + `version` | only `name` required; missing `version` falls back to git commit SHA |
-| `marketplace/version-semver` | `version` present + semver | root `version` is optional |
-| `schema/frontmatter-required` (skill) | `name` + `description` | `name` optional (defaults to dir name); `description` recommended (falls back to first body paragraph) |
-| `schema/frontmatter-required` (agent) | `name` + `description` | both genuinely required — matches spec |
+| `schema/parse` | Keep | None. |
+| `schema/frontmatter-required` | Decide | Skill `name`/`description` are optional/recommended per docs (name defaults to dir name; description falls back to first body paragraph). Agent `name`+`description` genuinely required — matches spec. Keep skill checks as best-practice but reword messages to not claim Claude Code requires them. |
+| `security/secrets` | Keep | None. Raw-source scan already covers new file surfaces. |
+| `style/no-emoji` | Keep | None. |
 
-Recommendation per row is in the Recommendation section. The skill-name
-check has a subtlety worth keeping: `name` only controls invocation for
-plugin-root SKILL.md, so requiring it is cheap hygiene, but the diagnostic
-message should stop implying Claude Code requires it.
+#### CLAUDE.md rules
 
-### Observation 3 — agents are a coverage hole
+| Rule | Verdict | Action needed |
+|---|---|---|
+| `claude_md/size` | Keep | Docs now advise "under 200 lines"; our default `max_lines = 500` is more lenient. Add a doc note; no behavior change. |
+| `claude_md/duplicate-directives` | Keep | None. |
 
-`KindAgent` exists, but the parser extracts only `name`, `description`,
-`tools` (`internal/artifact/parse_md_kinds.go:56-70`), and **zero
-agent-specific rules are registered** — agents get `schema/frontmatter-required`
-plus the every-kind rules and nothing else.
+#### Skill rules
 
-The current sub-agents doc defines 16 frontmatter fields: `name`,
-`description`, `model`, `tools`, `disallowedTools`, `permissionMode`,
-`maxTurns`, `skills`, `mcpServers`, `hooks`, `memory`, `background`,
-`effort`, `isolation`, `color`, `initialPrompt`. Three documented behaviors
-make agents unusually lint-worthy:
+| Rule | Verdict | Action needed |
+|---|---|---|
+| `skills/trigger-clarity` | Keep | Still valid — `description` drives auto-invocation. New `when_to_use` field carries trigger phrases too; rule should check the concatenation once the parser reads it. |
+| `skills/body-size` | Keep | Docs guidance is now "under 500 lines" (we count words, default 1000). Compatible; consider an optional `max_lines` variant. |
+| `skills/no-version-field` | Keep | Docs now explicitly confirm `version` is accepted-but-ignored. Rule validated; cite the doc in its help text. |
 
-1. **Unknown tool names in `tools` are silently ignored** by Claude Code —
-   a typo'd tool never errors at runtime; the agent just quietly lacks it.
-   This is exactly the failure mode a linter exists for.
-2. **`name` has a real constraint** (lowercase letters and hyphens only)
-   that Claude Code does not loudly enforce; duplicates resolve by
-   undocumented filesystem order.
-3. **Plugin subagents silently ignore `mcpServers`, `hooks`, and
-   `permissionMode`** — declaring them in a plugin's `agents/*.md` does
-   nothing. A rule can catch dead config that authors believe is active.
+#### Command rules
 
-### Observation 4 — the agent model question
+| Rule | Verdict | Action needed |
+|---|---|---|
+| `commands/allowed-tools-known` | Fix | (a) String form never splits on commas/whitespace — `allowed-tools: Read, Grep` is one unknown tool. (b) Permission-rule syntax (`Bash(git add:*)`), `mcp__*` patterns, and `Agent(...)` forms all flagged as unknown. (c) `KnownTools` (16 names) predates the `Task` → `Agent` rename and lacks `Agent`/`Skill`. (d) Commands and skills now share one frontmatter model — rule should also run on skill `allowed-tools`. |
 
-What the docs actually specify (`code.claude.com/docs/en/sub-agents.md`):
+#### Hook rules
+
+| Rule | Verdict | Action needed |
+|---|---|---|
+| `hooks/event-name-known` | Fix | Knows 9 of ~29 documented events; default-error rule fails valid configs (`SubagentStart`, `Setup`, `PermissionRequest`, ...). Expand list. |
+| `hooks/timeout-present` | Update | Command hooks have a documented 600 s default timeout — premise ("runaway hook can hang the session") is stale. Keep as style nudge; fix message + docs; account for per-type defaults (prompt 30 s, agent 60 s). |
+| `hooks/no-unsafe-shell` | Update | Only meaningful for `type: command` (and only shell-form: `args` present means exec-form, no shell). Needs `type` parsed to scope correctly and to skip exec-form false positives. |
+
+#### Plugin rules
+
+| Rule | Verdict | Action needed |
+|---|---|---|
+| `plugin/manifest-fields` | Keep (stricter) | Docs require only `name`; `version` optional (falls back to git SHA). Keep requiring `version` as an opinionated default — pinned versions are what marketplaces should ship — but document the stance and consider downgrading the version half to warning. |
+| `plugin/semver` | Keep | None. |
+
+#### Marketplace rules
+
+| Rule | Verdict | Action needed |
+|---|---|---|
+| `marketplace/name` | Keep | Presence check matches spec (kebab-case format is a new-rule candidate below). |
+| `marketplace/version-semver` | Update | Root `version` is optional per docs. Split: missing → info, present-but-not-semver → error. |
+| `marketplace/author-required` | Update | Docs make root `owner{name}` **required** (we treat author/owner as info-level nicety). Align: missing owner → warning or error; keep parsing both `author` and `owner` shapes (both documented). |
+| `marketplace/plugins-nonempty` | Keep | `plugins[]` required per docs; warning severity is a reasonable floor. |
+| `marketplace/plugin-source-valid` | Fix | Object sources (`github`/`url`/`git-subdir`/`npm`) parse as empty string → false positive on doc-valid marketplaces. After parser fix, validate documented per-type required fields (`repo`, `url`, `path`, `package`). |
+| `marketplace/plugin-name-unique` | Keep | Matches `claude plugin validate` behavior. |
+| `marketplace/plugin-name-matches-dir` | Keep | Style rule; scope to local-path sources only (object sources have no local dir). |
+| `marketplace/external-source-skipped` | Update | Once object sources are parsed they are structured data, not "skipped" — rework or retire this info rule. |
+
+#### MCP rules
+
+| Rule | Verdict | Action needed |
+|---|---|---|
+| `mcp/command-required` | Fix | `command` is required **only for stdio** transport. Doc-valid `http`/`ws` servers (url, no command) would false-positive once the `mcpServers` key fix lands. Scope to stdio; pair with new url-required rule. |
+| `mcp/server-name-required` | Keep | None. |
+| `mcp/command-exists-on-path` | Update | Scope to stdio transport. |
+| `mcp/no-unsafe-shell` | Keep | Still correct for stdio `command`. |
+| `mcp/no-secrets-in-env` | Update | Docs add `headers` (and `headersHelper`) — secrets in headers are at least as likely as in env. Extend or add sibling rule. |
+| `mcp/disabled-commented` | Keep | None. |
+| `mcp/server-allowlist` | Keep | None. (Opt-in pattern discussion below applies to the *next* opt-in rule, not this one.) |
+
+### Parser and shared-helper gaps
+
+Several "rule bugs" above are actually parser bugs — the rule layer never
+sees the data. These block the fixes and the new rules:
+
+| Parser / helper | Gap | Effect | Blocks |
+|---|---|---|---|
+| `ParseMCPFile` (`parse_mcp.go:37`) | Reads top-level `servers`; docs standardized on `mcpServers` | Doc-valid `.mcp.json` lints as zero servers — every MCP rule silently skips | All MCP rules |
+| `ParseMCPFile` server entries | Only `command`/`args`/`env`/`disabled`; no `type`, `url`, `headers`, `headersHelper`, `oauth`, `timeout`, `alwaysLoad` | Remote transports invisible; transport-aware scoping impossible | `mcp/command-required` fix, url-required, header secrets |
+| `ParseMarketplace` (`parse_marketplace.go`) | `source` read as string only | Object sources parse empty → `plugin-source-valid` false positive | Source-shape validation, reserved names |
+| `ParseHook` (`parse_json.go`) | `type` ignored; only `command`+`timeout` extracted | `http`/`mcp_tool`/`prompt`/`agent` hooks invisible; typo'd `type` passes | Hook type rules, `no-unsafe-shell` scoping |
+| `ParseAgent` (`parse_md_kinds.go:56`) | Only `name`/`description`/`tools` | No agent rules can see `model`, `disallowedTools`, `permissionMode`, `mcpServers`, `hooks`, etc. | Entire agent rule package |
+| `asStringList` (`parse_markdown.go:248`) | Never splits comma/space-separated strings | `allowed-tools`/`tools` string forms become single bogus entries | `commands/allowed-tools-known` fix, `agents/tools-known` |
+| `ParseSkill`/`ParseCommand` | Missing new fields (`when_to_use`, `model` on command, `context`, `agent`, `disable-model-invocation`, ...) | Limits skill/command rule expansion | `skills/description-length`, fork pairing, model-valid on commands |
+
+### Proposed new rules by kind
+
+Phase column maps to the [Recommendation](#recommendation): **PR 1** =
+correctness fixes, **PR 2** = agent package, **PR 3** = policy + design
+pass, **Backlog** = later.
+
+#### Agents (no rules exist today)
+
+| Proposed rule | Checks | Severity | Phase |
+|---|---|---|---|
+| `agents/model-valid` | `model` is an alias (`sonnet`/`opus`/`haiku`/`fable`), `inherit`, or full-ID shape (`^claude-[a-z0-9-]+$`). Catches typos that silently fall back to the inherited model. Same value set applies to skill/command `model` — share the validator. | warning | PR 2 |
+| `agents/name-format` | `name` is lowercase letters + hyphens only (documented constraint; duplicates resolve by undocumented filesystem order). | warning | PR 2 |
+| `agents/tools-known` | Entries in `tools`/`disallowedTools` are known tools, `mcp__*` patterns, or `Agent(...)` forms — Claude Code **silently ignores** unknown names. | warning | PR 2 |
+| `agents/plugin-ignored-fields` | Plugin-distributed agents declaring `mcpServers`, `hooks`, or `permissionMode` — documented as ignored for plugin subagents (dead config). | warning | PR 2 |
+| `agents/model-policy` | Opt-in enforcement: `require = "inherit"` or `allowlist = [...]`. | error (opt-in) | PR 3 |
+| `agents/field-enums` | `permissionMode` (7 values), `effort` (5), `color` (8), `isolation` (`worktree`), `memory` (`user`/`project`/`local`) are valid enum members. | warning | Backlog |
+
+#### Skills and commands
+
+| Proposed rule | Checks | Severity | Phase |
+|---|---|---|---|
+| `skills/description-length` | `description` + `when_to_use` combined ≤ 1,536 chars (documented truncation silently drops trigger phrases). | warning | PR 3 |
+| `skills/fork-agent-pairing` | `agent:` set without `context: fork` does nothing. | warning | Backlog |
+| (extend) `commands/allowed-tools-known` → skills | Same rule runs on skill `allowed-tools`/`disallowed-tools` after the merged-model parser update. | error | PR 1 |
+
+#### Hooks
+
+| Proposed rule | Checks | Severity | Phase |
+|---|---|---|---|
+| `hooks/type-known` | `type` ∈ `command`/`http`/`mcp_tool`/`prompt`/`agent` (absent defaults to `command`). | error | PR 3 |
+| `hooks/type-fields` | Per-type required fields present: `command` → `command`; `http` → `url`; `mcp_tool` → `server`+`tool`; `prompt`/`agent` → `prompt`. | error | PR 3 |
+
+#### Marketplaces
+
+| Proposed rule | Checks | Severity | Phase |
+|---|---|---|---|
+| `marketplace/reserved-name` | Name not in the 16 documented reserved names (and obvious impersonations); claude.ai sync blocks these. | error | PR 3 |
+| `marketplace/name-format` | Marketplace + plugin-entry names kebab-case (claude.ai sync rejects violations). | warning | PR 3 |
+| `marketplace/source-path-safety` | Relative sources start with `./`; no `..` traversal (validator-rejected). | error | PR 3 |
+| `marketplace/renames-valid` | `renames{}` chains terminate (at `null` or a listed plugin) and contain no cycles. | error | Backlog |
+
+#### MCP servers
+
+| Proposed rule | Checks | Severity | Phase |
+|---|---|---|---|
+| `mcp/url-required` | `http`/`sse`/`ws` transports declare `url` (counterpart to stdio-scoped `command-required`). | error | PR 1 |
+| `mcp/transport-known` | `type` ∈ `stdio`/`http`/`sse`/`ws`; flag `sse` as documented-deprecated (info). | warning | PR 3 |
+| `mcp/no-secrets-in-headers` | Secrets scan over `headers` values (or fold into `no-secrets-in-env`). | error | PR 3 |
+| `mcp/timeout-minimum` | `timeout` is in **milliseconds** with documented minimum 1000 — catches seconds-vs-ms confusion. | warning | Backlog |
+
+#### CLAUDE.md
+
+| Proposed rule | Checks | Severity | Phase |
+|---|---|---|---|
+| `claude_md/import-exists` | `@path` imports resolve on disk; flag chains beyond the documented 4-hop depth. | warning | Backlog |
+
+#### Deliberately not chasing yet
+
+Path-scoped rule files (`.claude/rules/*.md` with `paths:` frontmatter) as a
+ninth artifact kind, LSP servers, output styles, monitors
+(`experimental.*`), and `userConfig` schema validation — monitors/themes are
+explicitly marked experimental in the docs; revisit when they stabilize.
+
+### Detail — divergences that produce wrong results today
+
+Supporting detail for the **Fix** verdicts above.
+
+**`.mcp.json` top-level key.** The watch-item in DESIGN-0002 §2.2 has
+resolved against us: every current doc example uses `mcpServers{}` at the
+root of project `.mcp.json`. `ParseMCPFile` reads `servers` — a
+doc-conforming `.mcp.json` lints as "no servers" and every MCP rule silently
+skips. Highest-value single fix in the audit. Migration: accept `mcpServers`
+as primary, keep `servers` for one release with a deprecation info
+diagnostic (mirrors how the hook flat-shape removal was handled in #14/#18).
+
+**Hook events and types.** The event list grew from our 9 to ~29, and hook
+entries gained four non-command types with distinct required fields and
+timeout defaults (command/http/mcp_tool 600 s; prompt 30 s; agent 60 s;
+`UserPromptSubmit` caps at 30 s). Command hooks also gained `args`
+(exec-form — no shell, so shell-smell heuristics don't apply), `async`,
+`asyncRewake`, `shell`, `if`, and `statusMessage`. `disableAllHooks` is a
+new settings-level key.
+
+**Marketplace sources.** Docs define object sources — `github{repo,ref,sha}`,
+`url{url,ref,sha}`, `git-subdir{url,path,ref,sha}`, `npm{package,version,registry}` —
+alongside `./`-prefixed relative strings. Note: INV-0005's nested
+`metadata.version` false positive is now **documented** backward-compat
+(`metadata.version`, `metadata.description`, `owner{name,email}`), so our
+existing fallback parsing is spec-compliant, not defensive.
+
+**`allowed-tools` forms.** Docs (skills + slash-commands, now one merged
+model): YAML list **or** space/comma-separated string; entries may be
+permission rules (`Bash(git add:*)`), MCP patterns (`mcp__github`,
+`mcp__server__*`), or `Agent(...)` forms. `Task` was renamed `Agent` in
+v2.1.63 (both valid).
+
+### Detail — rules stricter than the current spec
+
+Supporting detail for the **Decide** / **Keep (stricter)** verdicts: being
+stricter than the runtime is legitimate for a linter — Claude Code's
+runtime posture is "silently tolerate", ours is "loudly flag" — but each
+divergence should be a documented stance, not an accident. The rules doc
+should carry a "stricter than spec, by design" note on: skill
+`name`/`description` requiredness, plugin `version` requiredness. The one
+genuine correction: `marketplace/version-semver` errors on a *missing*
+root version that the docs call optional — that half should soften to info.
+
+### Detail — the agent model question
+
+What the docs specify:
 
 - Valid `model` values: aliases (`sonnet`, `opus`, `haiku`, `fable`), full
   model IDs (e.g. `claude-opus-4-8`), or `inherit`.
-- **Omitted means `inherit`** — the default changed to inherit-from-parent;
-  an explicit `inherit` and an absent key are equivalent (since v2.1.196
-  even via the `CLAUDE_CODE_SUBAGENT_MODEL` env override path).
+- **Omitted means `inherit`** — an explicit `inherit` and an absent key are
+  equivalent (since v2.1.196 even via the `CLAUDE_CODE_SUBAGENT_MODEL`
+  override path).
 - Values excluded by an org's `availableModels` allowlist are skipped at
-  resolution time and fall back to the inherited model — misconfiguration
-  degrades silently rather than failing.
+  resolution and silently fall back to the inherited model.
 
-That maps onto two rules with different jobs:
+Hence the two-rule split in the tables above: `agents/model-valid` is
+always-on typo protection (a bad value never errors at runtime — it
+silently resolves to the parent model); `agents/model-policy` is governance
+for repos/marketplaces that want a stance, where `require = "inherit"`
+treats an absent key as compliant and `allowlist` permits deliberate
+pinning (e.g. `haiku` for cheap utility agents).
 
-**`agents/model-valid` (validation — default-enabled, warning).** If `model`
-is present, check it is an alias, `inherit`, or matches a full-ID shape
-(`^claude-[a-z0-9-]+$`). Catches `model: sonet` typos, which today silently
-resolve to the inherited model. No options needed. Also applies verbatim to
-the skill/command `model` field (same value set per the skills doc), so the
-check should live in shared validation with per-kind registration.
-
-**`agents/model-policy` (enforcement — opt-in).** Governance rule for repos
-and marketplaces that want a stance, with an option taking one of two
-shapes:
-
-    rule "agents/model-policy" {
-      options = { require = "inherit" }   # every agent must inherit
-    }
-
-    rule "agents/model-policy" {
-      options = { allowlist = ["inherit", "haiku", "sonnet"] }
-    }
-
-`require = "inherit"` treats an absent key as compliant (absence ==
-inherit per the docs) and flags any pinned model — the right default for
-cost/consistency governance and for marketplace review. `allowlist` permits
-deliberate pinning (e.g. cheap models for utility agents) while blocking
-everything else.
-
-**Pattern tension worth deciding explicitly:** the house pattern
-(`mcp/server-allowlist`, per CLAUDE.md) is "default-enabled, nil option →
-loud config error". That is right for a security rule; for a governance
-rule it would make every un-configured repo yell about every agent.
-CLAUDE.md already anticipated this: "Adding `Rule.Enabled()` for one rule
-is over-engineering; **revisit only if multiple rules need the pattern**."
-`agents/model-policy` is that second rule. The Phase 4 design should either
-add an opt-in mechanism (config-driven enable, or `Rule.Enabled()`) or
-accept a documented silent no-op when the option is unset — silent no-op is
-acceptable here precisely because absence-of-policy is a valid state,
+**Pattern tension to resolve in PR 3's design:** the house opt-in pattern
+(`mcp/server-allowlist`) is "default-enabled, nil option → loud config
+error" — right for security, wrong for governance (every un-configured
+repo would yell about every agent). CLAUDE.md anticipated this: "revisit
+only if multiple rules need the pattern." `agents/model-policy` is that
+second rule. Options: add an opt-in mechanism (config-driven enable or
+`Rule.Enabled()`), or accept a documented silent no-op when unset — silent
+no-op is defensible here because absence-of-policy is a valid state,
 unlike absence-of-allowlist on a security rule.
-
-### Observation 5 — new surface with no coverage yet
-
-Lower urgency; candidates for the backlog rather than the next release.
-
-- **Agents (beyond Observation 3/4):** `agents/name-format` (lowercase +
-  hyphens), `agents/tools-known` (the silent-ignore catch),
-  `agents/plugin-ignored-fields` (plugin agents declaring
-  `mcpServers`/`hooks`/`permissionMode`), enum checks for
-  `permissionMode`/`effort`/`color`/`isolation`/`memory`.
-- **Skills:** `skills/description-length` — `description` + `when_to_use`
-  are truncated at 1,536 combined chars, so overlong descriptions lose
-  their trigger phrases silently; body-size guidance is now "under 500
-  lines" (our `max_words = 1000` is compatible; consider a lines variant).
-  `context: fork` / `agent` pairing check (an `agent` field without
-  `context: fork` does nothing).
-- **Marketplaces:** reserved-name check (16 reserved/impersonation-blocked
-  marketplace names documented), `renames{}` cycle validation, source path
-  traversal (`..` rejected), relative sources must start with `./`,
-  kebab-case name format (claude.ai sync rejects violations).
-- **Hooks:** per-type required-field validation once 1b lands;
-  `disableAllHooks` awareness; `timeout` unit sanity (seconds, not ms).
-- **MCP:** `sse` transport deprecation warning; secrets scanning in
-  `headers` (today only `env` is scanned); `timeout` minimum (1000 ms).
-- **CLAUDE.md:** `@path` import resolution (imports exist on disk; ≤ 4-hop
-  depth documented); the docs' size guidance is "under 200 lines" vs our
-  default `max_lines = 500` — defensible, but worth a comment in the rule.
-- **Not worth chasing yet:** path-scoped rule files (`.claude/rules/*.md`
-  with `paths:` frontmatter) as a ninth artifact kind, LSP servers, output
-  styles, monitors (`experimental.*`), `userConfig` schema validation.
-  Revisit when they stabilize (monitors/themes are explicitly marked
-  experimental).
 
 ## Conclusion
 
 **Answer: Yes — the ruleset has drifted, in both directions.**
 
-Seven findings produce wrong results today (Observation 1), the worst being
-the `.mcp.json` `servers` → `mcpServers` divergence (valid files lint as
-empty) and the 9-of-29 hook-event list (valid configs fail with errors).
-Four rules are deliberately-or-accidentally stricter than the documented
-spec (Observation 2). Agents — the artifact kind Donald asked about — have
-the largest gap: a 16-field documented spec, three silent-failure behaviors
-worth linting, and zero agent rules shipped (Observation 3).
+Of 30 shipping rules: **4 Fix** (wrong against doc-valid input),
+**7 Update**, **17 Keep**, **2 Decide/Keep-stricter** — see the per-kind
+tables. The worst two fixes are the `.mcp.json` `servers` → `mcpServers`
+divergence (valid files lint as empty) and the 9-of-29 hook-event list
+(valid configs fail with errors). Seven parser gaps block most of the
+fixes and all of the agent work. Agents have the largest greenfield gap: a
+16-field documented spec, three silent-failure behaviors worth linting,
+and zero agent rules shipped.
 
-On the model question (Observation 4): yes, and it should be two rules —
-always-on **validation** of the value set (`sonnet`/`opus`/`haiku`/`fable`/
-full-ID/`inherit`), and **opt-in enforcement** (`require = "inherit"` or an
-allowlist) following — and finally forcing the anticipated revisit of — the
-opt-in-rule pattern.
+On the model question: yes, and it should be two rules — always-on
+**validation** of the value set (`sonnet`/`opus`/`haiku`/`fable`/full-ID/
+`inherit`), and **opt-in enforcement** (`require = "inherit"` or an
+allowlist), which forces the anticipated opt-in-pattern design decision.
 
 ## Recommendation
 
 Phase the work as three PRs, in this order:
 
-1. **Correctness fixes (patch/minor, no new rules):** expand
-   `KnownHookEvents` to the full documented set; accept `mcpServers` as the
-   primary `.mcp.json` key (keep `servers` with a deprecation info
-   diagnostic for one release); parse marketplace object sources so
-   `plugin-source-valid` stops false-positive-ing (and start validating the
-   documented per-type required fields); split string-form `allowed-tools`
-   on commas/whitespace and accept permission-rule + `mcp__*` syntax;
-   refresh `KnownTools` (add `Agent`, `Skill`; keep `Task` as alias).
-   Update Observation 2 rows: keep `plugin/manifest-fields` and skill
-   frontmatter checks as documented stricter-than-spec defaults, but split
-   `marketplace/version-semver` (missing → info, non-semver → error).
-2. **Agent rule package (minor):** `agents/model-valid`,
-   `agents/name-format`, `agents/tools-known`,
-   `agents/plugin-ignored-fields` — requires extending the agent parser to
-   the documented field set (at minimum `model`, `disallowedTools`,
-   `permissionMode`, `mcpServers`, `hooks`, plus ranges). This bumps the
-   ruleset fingerprint and needs the coverage-gate check per package.
-3. **Policy + design pass:** `agents/model-policy` plus the opt-in
-   mechanism decision (second consumer of the pattern → design the
-   general solution), hook per-type validation, MCP transport rules.
-   Items in Observation 5 feed the backlog.
+1. **PR 1 — correctness fixes (no new rules except `mcp/url-required`):**
+   everything marked Fix + the parser gaps that back them — `mcpServers`
+   key (deprecation path for `servers`), full hook-event list, marketplace
+   object sources, `allowed-tools` string splitting + permission-rule
+   syntax, `KnownTools` refresh. Split `marketplace/version-semver`
+   severities. Update DESIGN-0002 §2.2 and the affected rules docs.
+2. **PR 2 — agent rule package:** extend `ParseAgent` to the documented
+   field set, then `agents/model-valid`, `agents/name-format`,
+   `agents/tools-known`, `agents/plugin-ignored-fields`. Fingerprint bump;
+   per-package coverage gate applies.
+3. **PR 3 — policy + design pass:** `agents/model-policy` plus the opt-in
+   mechanism decision, hook type rules, MCP transport rules, marketplace
+   name/safety rules. Backlog rows feed later phases.
 
-Write a DESIGN doc (Phase 4 / DESIGN-0005) covering 2–3 before
-implementing; item 1 is executable directly against DESIGN-0001/0002 with
-doc updates to the affected sections (DESIGN-0002 §2.2 in particular).
+Write DESIGN-0005 covering PRs 2–3 before implementing; PR 1 is executable
+directly against DESIGN-0001/0002 with doc updates to the affected sections.
 
 ## References
 

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -25,6 +25,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0003 | Phase 1.8 dogfood findings on external Claude plugins | Closed | 2026-04-21 | Donald Gifford | [0003-phase-18-dogfood-findings-on-external-claude-plugins.md](0003-phase-18-dogfood-findings-on-external-claude-plugins.md) |
 | INV-0004 | Donald-loop stop hook silently fails promise detection on transcripts with unescaped newlines | Closed | 2026-04-21 | Donald Gifford | [0004-donald-loop-stop-hook-silently-fails-promise-detection-on.md](0004-donald-loop-stop-hook-silently-fails-promise-detection-on.md) |
 | INV-0005 | Phase 2 dogfood findings: marketplaces, MCP, and spec divergence | Closed | 2026-04-23 | Donald Gifford | [0005-phase-2-dogfood-findings-marketplaces-mcp-and-spec-divergence.md](0005-phase-2-dogfood-findings-marketplaces-mcp-and-spec-divergence.md) |
+| INV-0006 | Rule coverage audit against current Claude Code docs | Concluded | 2026-07-09 | Donald Gifford | [0006-rule-coverage-audit-against-current-claude-code-docs.md](0006-rule-coverage-audit-against-current-claude-code-docs.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
         - 'IMPL-0001: Phase 1: core linter for CLAUDE.md, skills, plugins, and hooks': impl/0001-phase-1-core-linter-for-claudemd-skills-plugins-and-hooks.md
         - 'IMPL-0002: Phase 2 — marketplaces, MCP rules, SARIF, and GitHub Action': impl/0002-phase-2-marketplaces-mcp-rules-sarif-and-github-action.md
         - 'IMPL-0003: Phase 3 — Dual-output docs site with Starlight': impl/0003-phase-3-dual-output-docs-site-with-starlight.md
+        - 'IMPL-0004: Phase 4 - Ruleset alignment and agent rules': impl/0004-phase-4-ruleset-alignment-and-agent-rules.md
     - Investigations:
         - Overview: investigation/README.md
         - 'INV-0001: OpenAI and OpenCode skill/plugin format compatibility with Claude': investigation/0001-openai-and-opencode-skill-and-plugin-format-compatibility-with.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
         - 'INV-0003: Phase 1.8 dogfood findings on external Claude plugins': investigation/0003-phase-18-dogfood-findings-on-external-claude-plugins.md
         - 'INV-0004: Donald-loop stop hook silently fails promise detection on transcripts with unescaped newlines': investigation/0004-donald-loop-stop-hook-silently-fails-promise-detection-on.md
         - 'INV-0005: Phase 2 dogfood findings: marketplaces, MCP, and spec divergence': investigation/0005-phase-2-dogfood-findings-marketplaces-mcp-and-spec-divergence.md
+        - 'INV-0006: Rule coverage audit against current Claude Code docs': investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md
     - Plans:
         - Overview: plan/README.md
     - RFCs:


### PR DESCRIPTION
Adds [INV-0006](docs/investigation/0006-rule-coverage-audit-against-current-claude-code-docs.md): a systematic diff of ruleset v1.2.0 (30 rules, fingerprint `e7f26796`) against the current `code.claude.com` documentation for agents, skills, commands, plugins, marketplaces, hooks, MCP servers, and CLAUDE.md. Docs fetched 2026-07-09 (version markers through Claude Code v2.1.205).

## Structure

The findings are audit tables, per artifact kind:

- **Existing rules — audit by kind**: all 30 rules with a verdict — **4 Fix** (wrong against doc-valid input today), **7 Update**, **17 Keep**, **2 Decide/Keep-stricter** — and the concrete action per rule.
- **Parser and shared-helper gaps**: 7 parser-level gaps and which rule fixes each one blocks (several "rule bugs" are actually parser bugs).
- **Proposed new rules by kind**: ~18 candidates with severity and phase — every one lands in PR 1, 2, or 3.
- **Detail sections** backing the verdicts, including the agent `model` question.

## Headline findings

- `.mcp.json` is documented as top-level `mcpServers{}`; we parse `servers{}` — the DESIGN-0002 §2.2 watch-item resolved against us. Doc-valid files lint as "no servers".
- `hooks/event-name-known` knows 9 of ~29 documented events — valid configs using e.g. `SubagentStart` fail with errors.
- Hooks have five documented types (`command`/`http`/`mcp_tool`/`prompt`/`agent`); we ignore `type`. Command hooks have a documented 600s default timeout.
- Marketplace object sources (`github`/`url`/`git-subdir`/`npm`) parse as empty → `plugin-source-valid` false-positives. (INV-0005's nested `metadata.version` finding is now *documented* backward-compat.)
- String-form `allowed-tools` never splits on commas/spaces; permission-rule syntax and `mcp__*` flagged as unknown; `KnownTools` predates the `Task` → `Agent` rename.
- **Agents**: 16-field documented frontmatter spec, zero agent rules shipped. Proposal: `agents/model-valid` (always-on value validation; omitted == `inherit`, invalid values silently fall back at runtime) + opt-in `agents/model-policy` (`require = "inherit"` | `allowlist`) — the second consumer that forces the anticipated opt-in-pattern revisit.

## Recommended sequencing (from the doc)

1. **PR 1** — correctness fixes to existing parsers/rules (+ `mcp/url-required` as `command-required`'s transport counterpart)
2. **PR 2** — agent rule package (extend `ParseAgent`, four new rules; needs DESIGN-0005)
3. **PR 3** — policy rules + opt-in mechanism design; all remaining proposed rules (nothing deferred to a backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also in this PR: IMPL-0004

[IMPL-0004](docs/impl/0004-phase-4-ruleset-alignment-and-agent-rules.md) turns the INV's three-PR recommendation into a five-phase tracker with checkbox tasks and per-phase success criteria:

1. **Parser foundations** + 2. **Correctness rule fixes** — one PR/minor release (fixes the four wrong-today rules, adds `mcp/url-required`)
3. **DESIGN-0005 gate** — agent package spec + the opt-in mechanism decision (docs-only)
4. **Agent rule package** — `model-valid`, `name-format`, `tools-known`, `plugin-ignored-fields`, `field-enums`
5. **Policy + remaining validation** — `agents/model-policy` and the 12-rule batch

**All 8 open questions resolved 2026-07-10 on option (a)** — see the Resolved Decisions section in IMPL-0004. Implementation is unblocked on merge.

